### PR TITLE
feat: add bidirectional peer routing between daemons

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,19 @@ In addition to local sessions, you can manage Claude Code sessions running on EC
 
 The Master daemon on your local machine communicates with Slave daemons on remote hosts via SSH tunnels (or Docker volume mounts). The Slave runs the same `ccvalet daemon` binary.
 
+Communication is **bidirectional**: the Master establishes a forward tunnel (`-L`) to reach the Slave, and a reverse tunnel (`-R`) so the Slave can reach the Master back. This allows either side to act as an orchestrator. A `visited` array in each request prevents routing loops.
+
+Each daemon has a **host ID** (default: `"local"`). You can set it in `config.yaml` or via the `--host-id` flag:
+
+```yaml
+# ~/.ccvalet/config.yaml
+host_id: mac   # Identifies this daemon in bidirectional routing
+hosts:
+  - id: ec2
+    type: ssh
+    host: my-ec2-instance
+```
+
 ### EC2 Setup
 
 **1. Install ccvalet and tmux on EC2 (first time only)**

--- a/cmd/ccvalet/cmd/daemon.go
+++ b/cmd/ccvalet/cmd/daemon.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/takaaki-s/claude-code-valet/internal/config"
 	"github.com/takaaki-s/claude-code-valet/internal/daemon"
 )
 
@@ -17,6 +18,9 @@ type daemonStatusResult struct {
 }
 
 var socketPathFlag string
+var hostIDFlag string
+var peerSocketFlag string
+var peerIDFlag string
 
 var daemonCmd = &cobra.Command{
 	Use:   "daemon",
@@ -29,10 +33,21 @@ var daemonCmd = &cobra.Command{
 			return fmt.Errorf("daemon is already running. Use 'ccvalet daemon stop' to stop it first")
 		}
 
-		server, err := daemon.NewServer(getSocketPath(), getDataDir(), getConfigDir())
+		hostID := resolveHostID()
+		server, err := daemon.NewServer(getSocketPath(), getDataDir(), getConfigDir(), hostID)
 		if err != nil {
 			return err
 		}
+
+		// Register peer if --peer-socket and --peer-id are specified (slave mode)
+		if (peerSocketFlag != "") != (peerIDFlag != "") {
+			return fmt.Errorf("--peer-socket and --peer-id must be specified together")
+		}
+		if peerSocketFlag != "" && peerIDFlag != "" {
+			peerClient := daemon.NewRemoteClient(peerSocketFlag, peerIDFlag)
+			server.RegisterPeer(peerIDFlag, "ssh", peerClient)
+		}
+
 		return server.Start()
 	},
 }
@@ -52,6 +67,15 @@ var daemonStartCmd = &cobra.Command{
 		daemonArgs := []string{"daemon"}
 		if socketPathFlag != "" {
 			daemonArgs = append(daemonArgs, "--socket", socketPathFlag)
+		}
+		if hostIDFlag != "" {
+			daemonArgs = append(daemonArgs, "--host-id", hostIDFlag)
+		}
+		if peerSocketFlag != "" {
+			daemonArgs = append(daemonArgs, "--peer-socket", peerSocketFlag)
+		}
+		if peerIDFlag != "" {
+			daemonArgs = append(daemonArgs, "--peer-id", peerIDFlag)
 		}
 		bgCmd := exec.Command(exe, daemonArgs...)
 		bgCmd.Env = os.Environ() // Inherit environment variables
@@ -120,10 +144,30 @@ func init() {
 
 	// --socket flag: specify custom socket path for slave mode
 	daemonCmd.PersistentFlags().StringVar(&socketPathFlag, "socket", "", "custom socket path (for slave mode)")
+	// --host-id flag: set this daemon's host ID for bidirectional routing
+	daemonCmd.PersistentFlags().StringVar(&hostIDFlag, "host-id", "", "host ID for this daemon (default: config value or \"local\")")
+	// --peer-socket / --peer-id flags: register a peer daemon (used by master to tell slave about reverse tunnel)
+	daemonCmd.PersistentFlags().StringVar(&peerSocketFlag, "peer-socket", "", "peer daemon socket path (reverse tunnel)")
+	daemonCmd.PersistentFlags().StringVar(&peerIDFlag, "peer-id", "", "peer daemon host ID")
 }
 
 func renderDaemonStatusJSON(w io.Writer, result daemonStatusResult) error {
 	return writeJSON(w, result)
+}
+
+// resolveHostID determines the host ID with priority: flag > config > "local"
+func resolveHostID() string {
+	if hostIDFlag != "" {
+		return hostIDFlag
+	}
+	// Try loading from config
+	configDir := getConfigDir()
+	if configMgr, err := config.NewManager(configDir); err == nil {
+		if id := configMgr.GetHostID(); id != "" {
+			return id
+		}
+	}
+	return "local"
 }
 
 func getSocketPath() string {

--- a/docs/ipc-protocol.md
+++ b/docs/ipc-protocol.md
@@ -11,8 +11,9 @@
 ```go
 // Request (client → server)
 type Request struct {
-    Action string          `json:"action"`
-    Data   json.RawMessage `json:"data,omitempty"`
+    Action  string          `json:"action"`
+    Data    json.RawMessage `json:"data,omitempty"`
+    Visited []string        `json:"visited,omitempty"` // Host IDs already visited (loop prevention)
 }
 
 // Response (server → client)
@@ -62,10 +63,21 @@ type HookRequest struct {
 }
 ```
 
-## Remote Forwarding
+## Bidirectional Routing
 
-When `host_id` is not "local", the Master daemon forwards the request to the corresponding Slave.
-The `host_id` field is stripped before forwarding to prevent recursive forwarding by the Slave.
+Daemons use visited-based routing to support bidirectional communication between hosts.
+
+When `host_id` is not "local" and not the current daemon's own host ID, the request is forwarded to the target host. Before forwarding, the current daemon's `hostID` is appended to `req.Visited`. If the target `hostID` is already in `Visited`, a "routing loop detected" error is returned.
+
+For aggregation actions (`list`, `notification-history`), the daemon queries all reachable hosts (configured remotes + peers registered via reverse tunnel), skipping any host already in `Visited`.
+
+### Peer Registration
+
+A peer is a daemon connected via SSH reverse tunnel (`-R`). When the master starts a slave, it passes `--peer-socket` and `--peer-id` flags. The slave uses these to register the master as a peer, enabling bidirectional communication.
+
+### Host ID
+
+Each daemon has a `hostID` (flag `--host-id` > config `host_id` > default `"local"`). This ID is used in `Visited` arrays and for tagging sessions/notifications.
 
 ## Adding a New Action
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,6 +63,7 @@ type HostConfig struct {
 
 // Config represents the application-wide configuration
 type Config struct {
+	HostID      string            `mapstructure:"host_id,omitempty"`     // This daemon's host ID (default: "local")
 	Keybindings KeybindingsConfig `mapstructure:"keybindings,omitempty"` // Keybinding settings
 	Hosts       []HostConfig      `mapstructure:"hosts,omitempty"`       // Remote host settings
 }
@@ -300,6 +301,13 @@ func (m *Manager) GetKeybindings() KeybindingsConfig {
 	}
 
 	return cfg
+}
+
+// GetHostID returns the configured host ID (empty string if not set)
+func (m *Manager) GetHostID() string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.config.HostID
 }
 
 // GetDetachKey returns the byte value of the detach key used while attached

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -299,6 +299,31 @@ func (c *Client) RemoveDirHistory(hostID, path string) error {
 	return nil
 }
 
+// SendRaw sends a raw JSON request and returns the raw JSON response.
+// Implements host.SlaveClient interface for use in forwardToHost.
+func (c *Client) SendRaw(action string, data, visited []byte) ([]byte, error) {
+	req := Request{Action: action}
+	if data != nil {
+		req.Data = json.RawMessage(data)
+	}
+	if visited != nil {
+		if err := json.Unmarshal(visited, &req.Visited); err != nil {
+			return nil, fmt.Errorf("invalid visited JSON: %w", err)
+		}
+	}
+
+	resp, err := c.send(req)
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := json.Marshal(resp)
+	if err != nil {
+		return nil, err
+	}
+	return raw, nil
+}
+
 // ListHosts retrieves the list of hosts
 func (c *Client) ListHosts() ([]HostInfo, error) {
 	resp, err := c.send(Request{Action: "list-hosts"})

--- a/internal/daemon/integration_test.go
+++ b/internal/daemon/integration_test.go
@@ -15,18 +15,30 @@ import (
 	"github.com/takaaki-s/claude-code-valet/internal/session"
 )
 
-// setupTestServer creates a Server and Client connected via a Unix socket in t.TempDir().
+// shortTempDir creates a short temporary directory under /tmp to avoid macOS
+// Unix socket path length limit (104 bytes). t.TempDir() paths are too long.
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "ccv-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return dir
+}
+
+// setupTestServer creates a Server and Client connected via a Unix socket.
 // The server runs in a background goroutine and is stopped on test cleanup.
 // We manage the listener directly to avoid data races in Server.Start()/Stop().
 func setupTestServer(t *testing.T) (*Server, *Client) {
 	t.Helper()
 
-	tmpDir := t.TempDir()
-	socketPath := filepath.Join(tmpDir, "test.sock")
+	tmpDir := shortTempDir(t)
+	socketPath := filepath.Join(tmpDir, "t.sock")
 	dataDir := filepath.Join(tmpDir, "sessions")
 	configDir := filepath.Join(tmpDir, "config")
 
-	server, err := NewServer(socketPath, dataDir, configDir)
+	server, err := NewServer(socketPath, dataDir, configDir, "local")
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
@@ -746,6 +758,10 @@ func (m *mockSlaveClient) ListWithHostID() ([]session.Info, error) {
 
 func (m *mockSlaveClient) NotificationHistoryWithHostID() ([]notify.Entry, error) {
 	return m.entries, m.err
+}
+
+func (m *mockSlaveClient) SendRaw(action string, data, visited []byte) ([]byte, error) {
+	return []byte(`{"success":true}`), nil
 }
 
 func TestPollRemoteOnce_NewEntries(t *testing.T) {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -30,6 +31,7 @@ var debugLog = debug.NewLogger("daemon-debug.log")
 // Server is the daemon server
 type Server struct {
 	socketPath   string
+	hostID       string          // This daemon's host ID (e.g., "mac", "ec2"; default "local")
 	manager      *session.Manager
 	configMgr    *config.Manager
 	stateMgr     *config.StateManager
@@ -42,8 +44,12 @@ type Server struct {
 
 // Message types
 type Request struct {
-	Action string          `json:"action"`
-	Data   json.RawMessage `json:"data,omitempty"`
+	Action  string          `json:"action"`
+	Data    json.RawMessage `json:"data,omitempty"`
+	// Visited tracks host IDs that have already processed this request.
+	// Used by forwardToHost (targeted routing) and handleList/handleNotificationHistory
+	// (aggregation) to prevent routing loops in bidirectional daemon topologies.
+	Visited []string `json:"visited,omitempty"`
 }
 
 type Response struct {
@@ -53,7 +59,7 @@ type Response struct {
 }
 
 // NewServer creates a new daemon server
-func NewServer(socketPath, dataDir, configDir string) (*Server, error) {
+func NewServer(socketPath, dataDir, configDir, hostID string) (*Server, error) {
 	configMgr, err := config.NewManager(configDir)
 	if err != nil {
 		return nil, err
@@ -78,18 +84,23 @@ func NewServer(socketPath, dataDir, configDir string) (*Server, error) {
 		}
 	}
 
+	if hostID == "" {
+		hostID = "local"
+	}
+
 	s := &Server{
 		socketPath: socketPath,
+		hostID:     hostID,
 		manager:    mgr,
 		configMgr:  configMgr,
 		stateMgr:   stateMgr,
 	}
 
-	// Initialize multi-host support
+	// Initialize multi-host support (always create registry for peer registration)
 	hosts := configMgr.GetHosts()
+	s.tunnelMgr = tunnel.NewManager()
+	s.hostRegistry = host.NewRegistry(hosts)
 	if len(hosts) > 0 {
-		s.tunnelMgr = tunnel.NewManager()
-		s.hostRegistry = host.NewRegistry(hosts)
 		s.initRemoteSlaves()
 	}
 
@@ -178,7 +189,7 @@ func (s *Server) handleRequest(req *Request) Response {
 	case "new":
 		return s.handleNew(req.Data)
 	case "list":
-		return s.handleList()
+		return s.handleList(req.Visited)
 	case "get":
 		return s.handleGet(req.Data)
 	case "send":
@@ -196,7 +207,7 @@ func (s *Server) handleRequest(req *Request) Response {
 	case "hook":
 		return s.handleHook(req.Data)
 	case "notification-history":
-		return s.handleNotificationHistory()
+		return s.handleNotificationHistory(req.Visited)
 	case "dir-history":
 		return s.handleDirHistory(req.Data)
 	case "remove-dir-history":
@@ -224,45 +235,51 @@ func (s *Server) handleHook(data json.RawMessage) Response {
 	return Response{Success: true}
 }
 
-func (s *Server) handleNotificationHistory() Response {
+func (s *Server) handleNotificationHistory(visited []string) Response {
+	// Copy and add self to visited (avoid mutating caller's backing array)
+	visited = append(append([]string(nil), visited...), s.hostID)
+
 	// Get local notification history
 	localEntries := s.manager.NotificationHistory()
 	for i := range localEntries {
 		if localEntries[i].HostID == "" {
-			localEntries[i].HostID = "local"
+			localEntries[i].HostID = s.hostID
 		}
 	}
 
-	// Return only local if no remote hosts
+	// Return only local if no host registry
 	if s.hostRegistry == nil {
 		data, _ := json.Marshal(localEntries)
 		return Response{Success: true, Data: data}
 	}
 
-	// Fetch remote notification history in parallel and merge
+	// Fetch from all reachable hosts in parallel, skipping visited
 	allEntries := localEntries
-	remotes := s.hostRegistry.Remotes()
+	reachable := s.hostRegistry.AllReachable()
 
-	if len(remotes) > 0 {
+	var targets []*host.Host
+	for _, h := range reachable {
+		if !slices.Contains(visited, h.ID) && h.Client != nil {
+			targets = append(targets, h)
+		}
+	}
+
+	if len(targets) > 0 {
 		type remoteResult struct {
 			entries []notify.Entry
 			err     error
 			hostID  string
 		}
 
-		results := make(chan remoteResult, len(remotes))
-		for _, h := range remotes {
+		results := make(chan remoteResult, len(targets))
+		for _, h := range targets {
 			go func(rh *host.Host) {
-				if rh.Client == nil {
-					results <- remoteResult{hostID: rh.ID, err: fmt.Errorf("not connected")}
-					return
-				}
 				entries, err := rh.Client.NotificationHistoryWithHostID()
 				results <- remoteResult{entries: entries, err: err, hostID: rh.ID}
 			}(h)
 		}
 
-		for range remotes {
+		for range targets {
 			result := <-results
 			if result.err != nil {
 				debugLog("[REMOTE] Failed to get notification history from %s: %v", result.hostID, result.err)
@@ -301,7 +318,7 @@ func (s *Server) handleNew(data json.RawMessage) Response {
 		// The slave uses its own SSH_AUTH_SOCK from the SSH tunnel.
 		req.SSHAuthSock = ""
 		forwardData, _ := json.Marshal(req)
-		return s.forwardToSlave(req.HostID, Request{Action: "new", Data: forwardData})
+		return s.forwardToHost(req.HostID, Request{Action: "new", Data: forwardData})
 	}
 
 	// Synchronous mode - mutual exclusion
@@ -337,45 +354,51 @@ func (s *Server) handleNew(data json.RawMessage) Response {
 	return Response{Success: true, Data: respData}
 }
 
-func (s *Server) handleList() Response {
+func (s *Server) handleList(visited []string) Response {
+	// Copy and add self to visited (avoid mutating caller's backing array)
+	visited = append(append([]string(nil), visited...), s.hostID)
+
 	// Get local session list
 	localSessions := s.manager.List()
 	for i := range localSessions {
 		if localSessions[i].HostID == "" {
-			localSessions[i].HostID = "local"
+			localSessions[i].HostID = s.hostID
 		}
 	}
 
-	// Return only local if no remote hosts
+	// Return only local if no host registry
 	if s.hostRegistry == nil {
 		data, _ := json.Marshal(localSessions)
 		return Response{Success: true, Data: data}
 	}
 
-	// Fetch remote session list in parallel and merge
+	// Fetch from all reachable hosts (remotes + peers) in parallel, skipping visited
 	allSessions := localSessions
-	remotes := s.hostRegistry.Remotes()
+	reachable := s.hostRegistry.AllReachable()
 
-	if len(remotes) > 0 {
+	var targets []*host.Host
+	for _, h := range reachable {
+		if !slices.Contains(visited, h.ID) && h.Client != nil {
+			targets = append(targets, h)
+		}
+	}
+
+	if len(targets) > 0 {
 		type remoteResult struct {
 			sessions []session.Info
 			err      error
 			hostID   string
 		}
 
-		results := make(chan remoteResult, len(remotes))
-		for _, h := range remotes {
+		results := make(chan remoteResult, len(targets))
+		for _, h := range targets {
 			go func(rh *host.Host) {
-				if rh.Client == nil {
-					results <- remoteResult{hostID: rh.ID, err: fmt.Errorf("not connected")}
-					return
-				}
 				sessions, err := rh.Client.ListWithHostID()
 				results <- remoteResult{sessions: sessions, err: err, hostID: rh.ID}
 			}(h)
 		}
 
-		for range remotes {
+		for range targets {
 			result := <-results
 			if result.err != nil {
 				debugLog("[REMOTE] Failed to list from %s: %v", result.hostID, result.err)
@@ -397,7 +420,7 @@ func (s *Server) handleGet(data json.RawMessage) Response {
 
 	// Forward to the corresponding slave if destined for a remote host
 	if req.HostID != "" && req.HostID != "local" {
-		return s.forwardToSlave(req.HostID, Request{Action: "get", Data: data})
+		return s.forwardToHost(req.HostID, Request{Action: "get", Data: data})
 	}
 
 	sess, ok := s.manager.Get(req.ID)
@@ -442,7 +465,7 @@ func (s *Server) handleSend(data json.RawMessage) Response {
 
 	// Forward to the corresponding slave if destined for a remote host
 	if req.HostID != "" && req.HostID != "local" {
-		return s.forwardToSlave(req.HostID, Request{Action: "send", Data: data})
+		return s.forwardToHost(req.HostID, Request{Action: "send", Data: data})
 	}
 
 	if req.Prompt == "" {
@@ -467,7 +490,7 @@ func (s *Server) handleStart(data json.RawMessage) Response {
 
 	// Forward to the corresponding slave if destined for a remote host
 	if req.HostID != "" && req.HostID != "local" {
-		return s.forwardToSlave(req.HostID, Request{Action: "start", Data: data})
+		return s.forwardToHost(req.HostID, Request{Action: "start", Data: data})
 	}
 
 	if err := s.manager.StartBackground(req.ID); err != nil {
@@ -485,7 +508,7 @@ func (s *Server) handleKill(data json.RawMessage) Response {
 
 	// Forward to the corresponding slave if destined for a remote host
 	if req.HostID != "" && req.HostID != "local" {
-		return s.forwardToSlave(req.HostID, Request{Action: "kill", Data: data})
+		return s.forwardToHost(req.HostID, Request{Action: "kill", Data: data})
 	}
 
 	if err := s.manager.Kill(req.ID); err != nil {
@@ -503,7 +526,7 @@ func (s *Server) handleDelete(data json.RawMessage) Response {
 
 	// Forward to the corresponding slave if destined for a remote host
 	if req.HostID != "" && req.HostID != "local" {
-		return s.forwardToSlave(req.HostID, Request{Action: "delete", Data: data})
+		return s.forwardToHost(req.HostID, Request{Action: "delete", Data: data})
 	}
 
 	if err := s.manager.Delete(req.ID); err != nil {
@@ -522,6 +545,15 @@ func (s *Server) handleStop() Response {
 	return Response{Success: true}
 }
 
+// RegisterPeer registers a peer daemon (connected via reverse tunnel)
+func (s *Server) RegisterPeer(id, hostType string, client host.SlaveClient) {
+	if s.hostRegistry == nil {
+		return
+	}
+	s.hostRegistry.RegisterPeer(id, hostType, client)
+	debugLog("[PEER] Registered peer %s (type: %s)", id, hostType)
+}
+
 // --- Multi-host support ---
 
 // initRemoteSlaves starts slave daemons on remote hosts, establishes tunnels, and sets up daemon clients
@@ -530,16 +562,34 @@ func (s *Server) initRemoteSlaves() {
 		return
 	}
 
+	// Validate hostID before using it in shell commands (reverse tunnel, bootstrap)
+	if err := host.ValidateIdentifier(s.hostID); err != nil {
+		debugLog("[REMOTE] Invalid host ID %q: %v", s.hostID, err)
+		return
+	}
+
 	for _, h := range s.hostRegistry.Remotes() {
+		// Build peer options for bidirectional routing
+		peerSocketPath := filepath.Join(tunnel.PeerSocketDir, s.hostID, "daemon.sock")
+		bootstrapOpts := host.BootstrapOptions{
+			PeerSocketPath: peerSocketPath,
+			PeerHostID:     s.hostID,
+		}
+		tunnelOpts := tunnel.TunnelOptions{
+			ReverseEnabled:    true,
+			LocalHostID:       s.hostID,
+			LocalDaemonSocket: s.socketPath,
+		}
+
 		// Step 1: Auto-start slave daemon (idempotent: no-op if already running)
-		if err := host.StartSlave(h.Config); err != nil {
+		if err := host.StartSlave(h.Config, bootstrapOpts); err != nil {
 			debugLog("[REMOTE] Failed to start slave on %s: %v", h.ID, err)
 			continue
 		}
 		debugLog("[REMOTE] Slave started on %s", h.ID)
 
-		// Step 2: Establish SSH tunnel / Docker connection
-		localSocket, err := s.tunnelMgr.Open(h.Config)
+		// Step 2: Establish SSH tunnel / Docker connection (with reverse tunnel)
+		localSocket, err := s.tunnelMgr.Open(h.Config, tunnelOpts)
 		if err != nil {
 			debugLog("[REMOTE] Failed to open tunnel to %s: %v", h.ID, err)
 			continue
@@ -580,7 +630,7 @@ func (s *Server) pollRemoteNotifications() {
 // It fetches notification histories from all remote slaves, compares against
 // lastSeen timestamps, and sends local desktop notifications for new entries.
 func (s *Server) pollRemoteOnce(lastSeen map[string]time.Time) {
-	for _, h := range s.hostRegistry.Remotes() {
+	for _, h := range s.hostRegistry.AllReachable() {
 		if h.Client == nil {
 			continue
 		}
@@ -607,10 +657,15 @@ func (s *Server) pollRemoteOnce(lastSeen map[string]time.Time) {
 	}
 }
 
-// forwardToSlave forwards a request to a remote slave
-func (s *Server) forwardToSlave(hostID string, req Request) Response {
+// forwardToHost forwards a request to a remote or peer host using visited-based routing
+func (s *Server) forwardToHost(hostID string, req Request) Response {
 	if s.hostRegistry == nil {
 		return Response{Success: false, Error: "host registry not initialized"}
+	}
+
+	// Check for routing loop
+	if slices.Contains(req.Visited, hostID) {
+		return Response{Success: false, Error: "routing loop detected"}
 	}
 
 	h, ok := s.hostRegistry.Get(hostID)
@@ -622,28 +677,24 @@ func (s *Server) forwardToSlave(hostID string, req Request) Response {
 		return Response{Success: false, Error: fmt.Sprintf("host %s not connected", hostID)}
 	}
 
-	// Cast from SlaveClient interface to *Client
-	client, ok := h.Client.(*Client)
-	if !ok {
-		return Response{Success: false, Error: fmt.Sprintf("host %s has incompatible client type", hostID)}
-	}
+	// Add self to visited list before forwarding (copy to avoid mutating caller's slice)
+	visited := make([]string, len(req.Visited)+1)
+	copy(visited, req.Visited)
+	visited[len(req.Visited)] = s.hostID
+	req.Visited = visited
 
-	// Strip host_id from request data before forwarding to slave
-	// Prevents the slave from trying to forward again based on host_id
-	if req.Data != nil {
-		var m map[string]json.RawMessage
-		if err := json.Unmarshal(req.Data, &m); err == nil {
-			delete(m, "host_id")
-			req.Data, _ = json.Marshal(m)
-		}
-	}
-
-	resp, err := client.send(req)
+	// Use SlaveClient interface — no type assertion needed
+	visitedJSON, _ := json.Marshal(req.Visited)
+	rawResp, err := h.Client.SendRaw(req.Action, req.Data, visitedJSON)
 	if err != nil {
 		return Response{Success: false, Error: fmt.Sprintf("failed to forward to %s: %v", hostID, err)}
 	}
 
-	return *resp
+	var resp Response
+	if err := json.Unmarshal(rawResp, &resp); err != nil {
+		return Response{Success: false, Error: fmt.Sprintf("failed to decode response from %s: %v", hostID, err)}
+	}
+	return resp
 }
 
 // --- Host info queries ---
@@ -653,20 +704,22 @@ type HostInfo struct {
 	ID        string `json:"id"`
 	Type      string `json:"type"`
 	Connected bool   `json:"connected"`
+	IsPeer    bool   `json:"is_peer,omitempty"`
 }
 
 func (s *Server) handleListHosts() Response {
 	hosts := []HostInfo{
-		{ID: "local", Type: "local", Connected: true},
+		{ID: s.hostID, Type: "local", Connected: true},
 	}
 
 	if s.hostRegistry != nil {
-		for _, h := range s.hostRegistry.Remotes() {
+		for _, h := range s.hostRegistry.AllReachable() {
 			connected := h.Client != nil && h.Client.IsRunning()
 			hosts = append(hosts, HostInfo{
 				ID:        h.ID,
 				Type:      h.Type,
 				Connected: connected,
+				IsPeer:    h.IsPeer,
 			})
 		}
 	}

--- a/internal/daemon/visited_test.go
+++ b/internal/daemon/visited_test.go
@@ -1,0 +1,109 @@
+package daemon
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/takaaki-s/claude-code-valet/internal/host"
+)
+
+func TestRequest_VisitedJSON_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     Request
+		wantLen int
+	}{
+		{
+			name:    "with visited",
+			req:     Request{Action: "list", Visited: []string{"mac", "ec2"}},
+			wantLen: 2,
+		},
+		{
+			name:    "empty visited omitted",
+			req:     Request{Action: "list"},
+			wantLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.req)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+
+			var got Request
+			if err := json.Unmarshal(data, &got); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+
+			if len(got.Visited) != tt.wantLen {
+				t.Errorf("Visited len = %d, want %d", len(got.Visited), tt.wantLen)
+			}
+
+			if tt.wantLen > 0 {
+				if got.Visited[0] != "mac" || got.Visited[1] != "ec2" {
+					t.Errorf("Visited = %v, want [mac ec2]", got.Visited)
+				}
+			}
+		})
+	}
+}
+
+func TestRequest_VisitedJSON_OmitEmpty(t *testing.T) {
+	req := Request{Action: "list"}
+	data, _ := json.Marshal(req)
+
+	var m map[string]json.RawMessage
+	_ = json.Unmarshal(data, &m)
+
+	if _, ok := m["visited"]; ok {
+		t.Error("visited should be omitted when empty")
+	}
+}
+
+func TestRequest_VisitedJSON_BackwardCompat(t *testing.T) {
+	// Old format without visited field should still work
+	old := `{"action":"list","data":null}`
+	var req Request
+	if err := json.Unmarshal([]byte(old), &req); err != nil {
+		t.Fatalf("Unmarshal old format: %v", err)
+	}
+	if req.Visited != nil {
+		t.Errorf("Visited should be nil for old format, got %v", req.Visited)
+	}
+}
+
+func TestForwardToHost_VisitedCheck(t *testing.T) {
+	// No hostRegistry → should error with "not initialized"
+	s := &Server{hostID: "mac"}
+	req := Request{Action: "get", Visited: []string{"mac"}}
+	resp := s.forwardToHost("ec2", req)
+	if resp.Success {
+		t.Error("should fail when no host registry")
+	}
+	if resp.Error != "host registry not initialized" {
+		t.Errorf("error = %q, want 'host registry not initialized'", resp.Error)
+	}
+
+	// With registry, target already in visited → routing loop
+	s.hostRegistry = host.NewRegistry(nil)
+	req2 := Request{Action: "get", Visited: []string{"ec2"}}
+	resp2 := s.forwardToHost("ec2", req2)
+	if resp2.Success {
+		t.Error("should fail when target is in visited")
+	}
+	if resp2.Error != "routing loop detected" {
+		t.Errorf("error = %q, want 'routing loop detected'", resp2.Error)
+	}
+
+	// With registry, target not visited but unknown host
+	req3 := Request{Action: "get", Visited: []string{"mac"}}
+	resp3 := s.forwardToHost("unknown", req3)
+	if resp3.Success {
+		t.Error("should fail for unknown host")
+	}
+	if resp3.Error != "unknown host: unknown" {
+		t.Errorf("error = %q, want 'unknown host: unknown'", resp3.Error)
+	}
+}

--- a/internal/host/bootstrap.go
+++ b/internal/host/bootstrap.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/takaaki-s/claude-code-valet/internal/config"
 )
@@ -18,14 +19,51 @@ const (
 	defaultRemoteSocketPath = "~/.ccvalet/run/daemon.sock"
 )
 
+// BootstrapOptions configures optional peer information for the slave daemon
+type BootstrapOptions struct {
+	PeerSocketPath string // Reverse tunnel socket path on remote (e.g., /tmp/ccvalet-peers/mac/daemon.sock)
+	PeerHostID     string // Master daemon's host ID
+}
+
+// ValidateIdentifier checks that a string contains only safe characters for use
+// in shell commands (letters, digits, hyphens, underscores).
+func ValidateIdentifier(s string) error {
+	if s == "" {
+		return fmt.Errorf("identifier must not be empty")
+	}
+	for _, r := range s {
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '-' && r != '_' {
+			return fmt.Errorf("invalid character %q in identifier %q", r, s)
+		}
+	}
+	return nil
+}
+
+// validatePath checks that a string contains only safe characters for a file path.
+func validatePath(s string) error {
+	if s == "" {
+		return fmt.Errorf("path must not be empty")
+	}
+	for _, r := range s {
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) &&
+			r != '-' && r != '_' && r != '/' && r != '.' && r != '~' {
+			return fmt.Errorf("invalid character %q in path %q", r, s)
+		}
+	}
+	return nil
+}
+
 // StartSlaveCommand generates a command to start the slave daemon on a remote host
-func StartSlaveCommand(hostConfig config.HostConfig) *exec.Cmd {
+func StartSlaveCommand(hostConfig config.HostConfig, opts ...BootstrapOptions) *exec.Cmd {
 	socketPath := hostConfig.SocketPath
 	if socketPath == "" {
 		socketPath = defaultRemoteSocketPath
 	}
 
 	remoteCmd := fmt.Sprintf("ccvalet daemon start --socket %s", socketPath)
+	if len(opts) > 0 && opts[0].PeerSocketPath != "" && opts[0].PeerHostID != "" {
+		remoteCmd += fmt.Sprintf(" --peer-socket %s --peer-id %s", opts[0].PeerSocketPath, opts[0].PeerHostID)
+	}
 
 	switch hostConfig.Type {
 	case "ssh":
@@ -47,8 +85,18 @@ func StartSlaveCommand(hostConfig config.HostConfig) *exec.Cmd {
 
 // StartSlave starts the slave daemon on a remote host and returns the result.
 // Returns an error if ccvalet is not installed on the remote host.
-func StartSlave(hostConfig config.HostConfig) error {
-	cmd := StartSlaveCommand(hostConfig)
+func StartSlave(hostConfig config.HostConfig, opts ...BootstrapOptions) error {
+	// Validate peer options before building the shell command (prevent injection)
+	if len(opts) > 0 && opts[0].PeerSocketPath != "" && opts[0].PeerHostID != "" {
+		if err := validatePath(opts[0].PeerSocketPath); err != nil {
+			return fmt.Errorf("invalid peer socket path: %w", err)
+		}
+		if err := ValidateIdentifier(opts[0].PeerHostID); err != nil {
+			return fmt.Errorf("invalid peer host ID: %w", err)
+		}
+	}
+
+	cmd := StartSlaveCommand(hostConfig, opts...)
 	if cmd == nil {
 		return fmt.Errorf("unsupported host type: %s", hostConfig.Type)
 	}

--- a/internal/host/bootstrap_test.go
+++ b/internal/host/bootstrap_test.go
@@ -203,4 +203,70 @@ func TestStartSlaveCommand(t *testing.T) {
 			t.Errorf("expected nil for unknown type, got %v", cmd)
 		}
 	})
+
+	t.Run("ssh with BootstrapOptions", func(t *testing.T) {
+		hc := config.HostConfig{Type: "ssh", Host: "myhost"}
+		opts := BootstrapOptions{
+			PeerSocketPath: "/tmp/ccvalet-peers/mac/daemon.sock",
+			PeerHostID:     "mac",
+		}
+		cmd := StartSlaveCommand(hc, opts)
+		if cmd == nil {
+			t.Fatal("expected non-nil command")
+		}
+		lastArg := cmd.Args[len(cmd.Args)-1]
+		want := "ccvalet daemon start --socket ~/.ccvalet/run/daemon.sock --peer-socket /tmp/ccvalet-peers/mac/daemon.sock --peer-id mac"
+		if lastArg != want {
+			t.Errorf("remote command = %q, want %q", lastArg, want)
+		}
+	})
+}
+
+func TestValidateIdentifier(t *testing.T) {
+	tests := []struct {
+		input string
+		valid bool
+	}{
+		{"ec2", true},
+		{"my-host", true},
+		{"host_1", true},
+		{"Mac", true},
+		{"", false},
+		{"host;cmd", false},
+		{"host name", false},
+		{"../etc", false},
+	}
+	for _, tt := range tests {
+		err := ValidateIdentifier(tt.input)
+		if tt.valid && err != nil {
+			t.Errorf("ValidateIdentifier(%q) = %v, want nil", tt.input, err)
+		}
+		if !tt.valid && err == nil {
+			t.Errorf("ValidateIdentifier(%q) = nil, want error", tt.input)
+		}
+	}
+}
+
+func TestValidatePath(t *testing.T) {
+	tests := []struct {
+		input string
+		valid bool
+	}{
+		{"/tmp/ccvalet-peers/mac/daemon.sock", true},
+		{"~/.ccvalet/run/daemon.sock", true},
+		{"/a/b/c", true},
+		{"", false},
+		{"/tmp/foo;rm -rf /", false},
+		{"/tmp/foo bar", false},
+		{"/tmp/$HOME", false},
+	}
+	for _, tt := range tests {
+		err := validatePath(tt.input)
+		if tt.valid && err != nil {
+			t.Errorf("validatePath(%q) = %v, want nil", tt.input, err)
+		}
+		if !tt.valid && err == nil {
+			t.Errorf("validatePath(%q) = nil, want error", tt.input)
+		}
+	}
 }

--- a/internal/host/registry.go
+++ b/internal/host/registry.go
@@ -13,6 +13,9 @@ type SlaveClient interface {
 	IsRunning() bool
 	ListWithHostID() ([]session.Info, error)
 	NotificationHistoryWithHostID() ([]notify.Entry, error)
+	// SendRaw sends a raw JSON request and returns a raw JSON response.
+	// This avoids importing daemon types in the host package (no circular dependency).
+	SendRaw(action string, data, visited []byte) ([]byte, error)
 }
 
 // Host represents a host and its slave client pair
@@ -21,6 +24,7 @@ type Host struct {
 	Type   string            // "local", "ssh", "docker"
 	Config config.HostConfig // Host configuration
 	Client SlaveClient       // Connection to slave daemon (interface)
+	IsPeer bool              // true if this host was registered via reverse tunnel (peer)
 }
 
 // Registry manages the list of hosts
@@ -90,14 +94,14 @@ func (r *Registry) All() []*Host {
 	return result
 }
 
-// Remotes returns only remote hosts
+// Remotes returns only configured remote hosts (excludes local and peers)
 func (r *Registry) Remotes() []*Host {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
 	var result []*Host
 	for _, h := range r.hosts {
-		if h.ID != "local" {
+		if h.ID != "local" && !h.IsPeer {
 			result = append(result, h)
 		}
 	}
@@ -126,6 +130,47 @@ func (r *Registry) SetClient(hostID string, client SlaveClient) {
 	if h, ok := r.hosts[hostID]; ok {
 		h.Client = client
 	}
+}
+
+// RegisterPeer registers a peer host (connected via reverse tunnel).
+// Overwrites any existing entry with the same ID (e.g., on reconnect).
+func (r *Registry) RegisterPeer(id, hostType string, client SlaveClient) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.hosts[id] = &Host{
+		ID:     id,
+		Type:   hostType,
+		Client: client,
+		IsPeer: true,
+	}
+}
+
+// Peers returns only peer hosts (registered via reverse tunnel)
+func (r *Registry) Peers() []*Host {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var result []*Host
+	for _, h := range r.hosts {
+		if h.IsPeer {
+			result = append(result, h)
+		}
+	}
+	return result
+}
+
+// AllReachable returns all non-local hosts (remotes + peers)
+func (r *Registry) AllReachable() []*Host {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var result []*Host
+	for _, h := range r.hosts {
+		if h.ID != "local" {
+			result = append(result, h)
+		}
+	}
+	return result
 }
 
 // IsConnected returns whether the host is connected

--- a/internal/host/registry_peer_test.go
+++ b/internal/host/registry_peer_test.go
@@ -1,0 +1,102 @@
+package host
+
+import (
+	"testing"
+
+	"github.com/takaaki-s/claude-code-valet/internal/config"
+)
+
+func TestRegistry_RegisterPeer(t *testing.T) {
+	r := NewRegistry(nil)
+
+	client := &mockSlaveClient{running: true}
+	r.RegisterPeer("mac", "ssh", client)
+
+	h, ok := r.Get("mac")
+	if !ok {
+		t.Fatal("peer not found after RegisterPeer")
+	}
+	if !h.IsPeer {
+		t.Error("IsPeer should be true")
+	}
+	if h.Type != "ssh" {
+		t.Errorf("Type = %q, want ssh", h.Type)
+	}
+	if h.Client == nil {
+		t.Error("Client should not be nil")
+	}
+}
+
+func TestRegistry_Peers(t *testing.T) {
+	r := NewRegistry([]config.HostConfig{
+		{ID: "ec2", Type: "ssh"},
+	})
+
+	// No peers initially
+	peers := r.Peers()
+	if len(peers) != 0 {
+		t.Errorf("Peers() = %d, want 0 (no peers registered)", len(peers))
+	}
+
+	// Register a peer
+	r.RegisterPeer("mac", "ssh", &mockSlaveClient{running: true})
+
+	peers = r.Peers()
+	if len(peers) != 1 {
+		t.Fatalf("Peers() = %d, want 1", len(peers))
+	}
+	if peers[0].ID != "mac" {
+		t.Errorf("peer ID = %q, want mac", peers[0].ID)
+	}
+}
+
+func TestRegistry_AllReachable(t *testing.T) {
+	r := NewRegistry([]config.HostConfig{
+		{ID: "ec2", Type: "ssh"},
+	})
+
+	// Only remote, no peers
+	reachable := r.AllReachable()
+	if len(reachable) != 1 {
+		t.Fatalf("AllReachable() = %d, want 1", len(reachable))
+	}
+
+	// Add a peer
+	r.RegisterPeer("mac", "ssh", &mockSlaveClient{running: true})
+
+	reachable = r.AllReachable()
+	if len(reachable) != 2 {
+		t.Fatalf("AllReachable() = %d, want 2", len(reachable))
+	}
+
+	// Verify local is not included
+	for _, h := range reachable {
+		if h.ID == "local" {
+			t.Error("AllReachable() should not include local")
+		}
+	}
+}
+
+func TestRegistry_AllReachable_ExcludesLocal(t *testing.T) {
+	r := NewRegistry(nil)
+
+	reachable := r.AllReachable()
+	if len(reachable) != 0 {
+		t.Errorf("AllReachable() = %d, want 0 (only local)", len(reachable))
+	}
+}
+
+func TestRegistry_Remotes_ExcludesPeers(t *testing.T) {
+	r := NewRegistry([]config.HostConfig{
+		{ID: "ec2", Type: "ssh"},
+	})
+	r.RegisterPeer("mac", "ssh", &mockSlaveClient{running: true})
+
+	remotes := r.Remotes()
+	if len(remotes) != 1 {
+		t.Fatalf("Remotes() = %d, want 1 (peers excluded)", len(remotes))
+	}
+	if remotes[0].ID != "ec2" {
+		t.Errorf("remote ID = %q, want ec2", remotes[0].ID)
+	}
+}

--- a/internal/host/registry_test.go
+++ b/internal/host/registry_test.go
@@ -19,6 +19,9 @@ type mockSlaveClient struct {
 func (m *mockSlaveClient) IsRunning() bool                                    { return m.running }
 func (m *mockSlaveClient) ListWithHostID() ([]session.Info, error)            { return m.sessions, nil }
 func (m *mockSlaveClient) NotificationHistoryWithHostID() ([]notify.Entry, error) { return m.entries, nil }
+func (m *mockSlaveClient) SendRaw(action string, data, visited []byte) ([]byte, error) {
+	return []byte(`{"success":true}`), nil
+}
 
 // twoSSHHostConfigs returns a pair of SSH host configs for use in tests.
 func twoSSHHostConfigs() []config.HostConfig {

--- a/internal/tunnel/manager.go
+++ b/internal/tunnel/manager.go
@@ -30,6 +30,17 @@ type Tunnel struct {
 	cmd         *exec.Cmd
 }
 
+// TunnelOptions configures optional tunnel behavior
+type TunnelOptions struct {
+	ReverseEnabled    bool   // Enable reverse tunnel (-R) for bidirectional routing
+	LocalHostID       string // Master daemon's host ID (used for remote peer socket path)
+	LocalDaemonSocket string // Master daemon's local socket path
+}
+
+// PeerSocketDir is the directory for reverse tunnel peer sockets on the remote side.
+// Located in /tmp which is assumed to be single-user (e.g., EC2 instances).
+const PeerSocketDir = "/tmp/ccvalet-peers"
+
 // Manager manages tunnel connections
 type Manager struct {
 	mu      sync.RWMutex
@@ -44,10 +55,10 @@ func NewManager() *Manager {
 }
 
 // Open opens a tunnel based on host configuration
-func (m *Manager) Open(hostConfig config.HostConfig) (string, error) {
+func (m *Manager) Open(hostConfig config.HostConfig, opts ...TunnelOptions) (string, error) {
 	switch hostConfig.Type {
 	case "ssh":
-		return m.OpenSSH(hostConfig)
+		return m.OpenSSH(hostConfig, opts...)
 	case "docker":
 		return m.OpenDocker(hostConfig)
 	default:
@@ -57,7 +68,7 @@ func (m *Manager) Open(hostConfig config.HostConfig) (string, error) {
 
 // OpenSSH opens an SSH tunnel to forward the remote daemon socket
 // ssh -L {localSocket}:{remoteSocket} -N -f {host}
-func (m *Manager) OpenSSH(hostConfig config.HostConfig) (string, error) {
+func (m *Manager) OpenSSH(hostConfig config.HostConfig, opts ...TunnelOptions) (string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -102,11 +113,24 @@ func (m *Manager) OpenSSH(hostConfig config.HostConfig) (string, error) {
 	// Create a stable symlink for the SSH agent socket on the remote,
 	// so the slave daemon can use it for git fetch etc.
 	// Instead of -N (no command), create the symlink then sleep to keep the connection.
+	// Add reverse tunnel (-R) for bidirectional routing if requested
+	var reversePreamble string
+	if len(opts) > 0 && opts[0].ReverseEnabled && opts[0].LocalHostID != "" {
+		reverseSockRemote := fmt.Sprintf("%s/%s/daemon.sock", PeerSocketDir, opts[0].LocalHostID)
+		reverseSockLocal := opts[0].LocalDaemonSocket
+		args = append(args, "-R", reverseSockRemote+":"+reverseSockLocal)
+		// Ensure peer directory exists and clean up stale socket on remote
+		reversePreamble = fmt.Sprintf(
+			"mkdir -p %s/%s && rm -f %s; ",
+			PeerSocketDir, opts[0].LocalHostID, reverseSockRemote,
+		)
+	}
+
 	agentSymlink := "~/.ccvalet/ssh-agent.sock"
 	remoteCmd := fmt.Sprintf(
-		"mkdir -p ~/.ccvalet && test -n \"$SSH_AUTH_SOCK\" && ln -sf \"$SSH_AUTH_SOCK\" %s; "+
+		"%smkdir -p ~/.ccvalet && test -n \"$SSH_AUTH_SOCK\" && ln -sf \"$SSH_AUTH_SOCK\" %s; "+
 			"while sleep 3600; do :; done",
-		agentSymlink,
+		reversePreamble, agentSymlink,
 	)
 	args = append(args,
 		"-L", localSocket+":"+remoteSocket,

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -33,7 +33,7 @@ func setupE2E(t *testing.T) *daemon.Client {
 	dataDir := filepath.Join(tmpDir, "sessions")
 	configDir := filepath.Join(tmpDir, "config")
 
-	server, err := daemon.NewServer(socketPath, dataDir, configDir)
+	server, err := daemon.NewServer(socketPath, dataDir, configDir, "local")
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}

--- a/test/e2e/e2e_tmux_test.go
+++ b/test/e2e/e2e_tmux_test.go
@@ -26,7 +26,7 @@ func setupE2EWithDataDir(t *testing.T, dataDir, configDir string) (*daemon.Clien
 
 	socketPath := filepath.Join(t.TempDir(), "e2e-tmux.sock")
 
-	server, err := daemon.NewServer(socketPath, dataDir, configDir)
+	server, err := daemon.NewServer(socketPath, dataDir, configDir, "local")
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Add visited-based routing for bidirectional daemon communication via SSH reverse tunnels (`-R`)
- Each daemon has a `hostID` (`--host-id` flag / `config.yaml host_id`) for identification
- `SlaveClient.SendRaw` interface method replaces type assertion for forward routing
- `ValidateIdentifier`/`validatePath` prevent command injection in shell commands
- Fix macOS Unix socket path length limit (104 bytes) in integration tests

## Changes

| Area | Files | Description |
|------|-------|-------------|
| Protocol | `server.go` | `Request.Visited`, `Server.hostID`, `forwardToHost` with visited routing |
| Registry | `registry.go` | `Host.IsPeer`, `RegisterPeer`, `Peers`, `AllReachable` |
| Tunnel | `manager.go` | `TunnelOptions`, reverse tunnel (`-R`) in `OpenSSH` |
| Bootstrap | `bootstrap.go` | `BootstrapOptions`, `--peer-socket`/`--peer-id`, input validation |
| Config | `config.go` | `Config.HostID`, `GetHostID()` |
| CLI | `daemon.go` | `--host-id`, `--peer-socket`, `--peer-id` flags |
| Client | `client.go` | `SendRaw` implementing `SlaveClient` interface |
| Tests | `visited_test.go`, `registry_peer_test.go`, `bootstrap_test.go` | Visited JSON, loop prevention, peer registry, validation |
| Fix | `integration_test.go` | `shortTempDir` for macOS socket path limit |
| Docs | `README.md`, `ipc-protocol.md` | Bidirectional routing docs |

## Test plan

- [x] `make build` passes
- [x] `make lint` passes
- [x] All unit tests pass (`go test ./...`)
- [x] All daemon integration tests pass (macOS socket path fix)
- [x] Visited JSON roundtrip + backward compatibility
- [x] Routing loop detection (`"routing loop detected"` error)
- [x] Peer registry operations (RegisterPeer, AllReachable, Peers, Remotes excludes peers)
- [x] ValidateIdentifier/validatePath whitelist validation
- [x] Code review: 4 rounds, all must/want resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)