### PR TITLE
fix: transition running→idle when Claude Code fires no hook on startup

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -645,6 +645,33 @@ func (m *Manager) captureOutputTmux(session *Session) {
 				lastTrackedPath = currentPath
 			}
 		}
+
+		// Fallback: if the session has been in "running" since a fresh start and no
+		// hook has arrived within hookIdleTimeout, assume Claude is idle and waiting
+		// for input. This handles the case where Claude Code does not fire Stop or
+		// idle_prompt during initial startup.
+		//
+		// StartedAt is json:"-" (runtime-only) so it is always zero after a daemon
+		// restart. The !startedAt.IsZero() guard ensures this fallback never fires
+		// for daemon-recovered sessions (preventing false idle transitions while a
+		// task is still running).
+		m.mu.RLock()
+		fbStatus := session.Status
+		fbLastOutput := session.LastOutputTime
+		fbStartedAt := session.StartedAt
+		m.mu.RUnlock()
+
+		const hookIdleTimeout = 30 * time.Second
+		if fbStatus == StatusRunning && !fbStartedAt.IsZero() && time.Since(fbLastOutput) > hookIdleTimeout {
+			m.mu.Lock()
+			if _, exists := m.sessions[session.ID]; exists && session.Status == StatusRunning {
+				session.Status = StatusIdle
+				session.LastOutputTime = time.Now()
+				debugLog("[POLL] Session %s: running -> idle (no hook received for %s, fallback)", session.Name, hookIdleTimeout)
+			}
+			m.mu.Unlock()
+			_ = m.store.Save(session)
+		}
 	}
 }
 

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -1122,3 +1122,97 @@ func TestManager_EnsureClaudeTrustState_MultipleProjects(t *testing.T) {
 		t.Error("project 2 HasTrustDialogAccepted = false, want true")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Idle fallback tests (hook-timeout detection in captureOutputTmux)
+// ---------------------------------------------------------------------------
+
+// TestManager_IdleFallback_FreshStart verifies that a session in StatusRunning
+// with a non-zero StartedAt and stale LastOutputTime satisfies the fallback
+// condition that captureOutputTmux uses to transition running → idle.
+func TestManager_IdleFallback_FreshStart(t *testing.T) {
+	mgr, _ := newTestManager(t)
+
+	sess, err := mgr.CreateWithOptions(CreateOptions{WorkDir: "/tmp/idle-fallback-fresh", Name: "ifb-fresh"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Simulate a fresh start: status running, StartedAt and LastOutputTime set 31s ago.
+	mgr.mu.Lock()
+	sess.Status = StatusRunning
+	sess.StartedAt = time.Now().Add(-31 * time.Second)
+	sess.LastOutputTime = time.Now().Add(-31 * time.Second)
+	mgr.mu.Unlock()
+
+	const hookIdleTimeout = 30 * time.Second
+
+	mgr.mu.RLock()
+	fbStatus := sess.Status
+	fbLastOutput := sess.LastOutputTime
+	fbStartedAt := sess.StartedAt
+	mgr.mu.RUnlock()
+
+	// The condition must be true for the fallback to fire.
+	if !(fbStatus == StatusRunning && !fbStartedAt.IsZero() && time.Since(fbLastOutput) > hookIdleTimeout) {
+		t.Fatal("expected idle fallback condition to be true for a fresh start with stale LastOutputTime")
+	}
+
+	// Apply the same transition captureOutputTmux would perform.
+	mgr.mu.Lock()
+	if _, exists := mgr.sessions[sess.ID]; exists && sess.Status == StatusRunning {
+		sess.Status = StatusIdle
+		sess.LastOutputTime = time.Now()
+	}
+	mgr.mu.Unlock()
+
+	got, ok := mgr.Get(sess.ID)
+	if !ok {
+		t.Fatal("session not found after fallback transition")
+	}
+	if got.Status != StatusIdle {
+		t.Errorf("Status = %q, want %q", got.Status, StatusIdle)
+	}
+}
+
+// TestManager_IdleFallback_DaemonRecovery verifies that sessions recovered after
+// a daemon restart (StartedAt == zero) do NOT satisfy the fallback condition,
+// preventing false idle transitions while a task may still be running.
+func TestManager_IdleFallback_DaemonRecovery(t *testing.T) {
+	mgr, _ := newTestManager(t)
+
+	sess, err := mgr.CreateWithOptions(CreateOptions{WorkDir: "/tmp/idle-fallback-recover", Name: "ifb-recover"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Simulate daemon recovery: StartedAt is zero (json:"-" field, never set on recovery).
+	mgr.mu.Lock()
+	sess.Status = StatusRunning
+	// sess.StartedAt is zero by default — as it would be after daemon restart.
+	sess.LastOutputTime = time.Now().Add(-31 * time.Second)
+	mgr.mu.Unlock()
+
+	const hookIdleTimeout = 30 * time.Second
+
+	mgr.mu.RLock()
+	fbStatus := sess.Status
+	fbLastOutput := sess.LastOutputTime
+	fbStartedAt := sess.StartedAt
+	mgr.mu.RUnlock()
+
+	// The condition must be false (StartedAt.IsZero() == true), so fallback does not fire.
+	shouldFallback := fbStatus == StatusRunning && !fbStartedAt.IsZero() && time.Since(fbLastOutput) > hookIdleTimeout
+	if shouldFallback {
+		t.Error("idle fallback condition should be false when StartedAt is zero (daemon recovery)")
+	}
+
+	// Status must remain running.
+	got, ok := mgr.Get(sess.ID)
+	if !ok {
+		t.Fatal("session not found")
+	}
+	if got.Status != StatusRunning {
+		t.Errorf("Status = %q, want %q (should not change without hook)", got.Status, StatusRunning)
+	}
+}


### PR DESCRIPTION
When a new session is started with `claude --session-id`, Claude Code does
not reliably fire a Stop hook or idle_prompt notification during initial
startup. The session would remain stuck in StatusRunning indefinitely until
the user sent their first message.

Add a fallback in captureOutputTmux: if the session has been in StatusRunning
for more than 30 seconds without receiving any hook event (measured via
LastOutputTime), automatically transition to StatusIdle.

The StartedAt.IsZero() guard prevents false positives for daemon-recovered
sessions, where StartedAt is always zero (runtime-only json:"-" field) and
Claude may still be mid-task.
