### PR TITLE
docs: fix Go version requirement in README to match go.mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ tail -f ~/.ccvalet/debug.log
 
 ## Requirements
 
-- Go 1.21+
+- Go 1.24.5+
 - tmux 3.3+
 - Claude Code CLI installed
 


### PR DESCRIPTION
README.md listed Go 1.21+ but go.mod requires Go 1.24.5.

https://claude.ai/code/session_012ScM9PcrVmFQtDQVsWymkq