### PR TITLE
refactor: fleet フィールドのデフォルト値を "default" に統一

### DIFF
--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -304,7 +304,7 @@ type NewRequest struct {
 	Start       bool   `json:"start"`
 	HostID      string `json:"host_id,omitempty"`       // Target host (empty = "local")
 	SSHAuthSock string `json:"ssh_auth_sock,omitempty"` // SSH_AUTH_SOCK (for git operations)
-	Fleet       string `json:"fleet,omitempty"`         // Fleet name for session grouping
+	Fleet       string `json:"fleet"`                   // Fleet name for session grouping
 }
 
 func (s *Server) handleNew(data json.RawMessage) Response {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -155,6 +155,9 @@ func NewManager(dataDir, configDir string, configMgr *config.Manager) (*Manager,
 	}
 	for _, s := range sessions {
 		s.Status = StatusStopped // All loaded sessions start as stopped
+		if s.Fleet == "" {
+			s.Fleet = DefaultFleet
+		}
 		m.sessions[s.ID] = s
 	}
 
@@ -165,13 +168,17 @@ func NewManager(dataDir, configDir string, configMgr *config.Manager) (*Manager,
 type CreateOptions struct {
 	WorkDir string // Working directory path
 	Name    string // Session name (defaults to directory basename)
-	Fleet   string // Fleet name for session grouping (empty = "default")
+	Fleet   string // Fleet name for session grouping; defaults to DefaultFleet if empty
 }
 
 // CreateWithOptions creates a new session with full options
 func (m *Manager) CreateWithOptions(opts CreateOptions) (*Session, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	if opts.Fleet == "" {
+		opts.Fleet = DefaultFleet
+	}
 
 	// WorkDir is required
 	if opts.WorkDir == "" {
@@ -249,22 +256,15 @@ func (m *Manager) List() []Info {
 		}
 	}
 
-	// Sort by Fleet (alphabetically, empty/"default" last), then by CreatedAt (oldest first)
+	// Sort by Fleet (alphabetically, "default" last), then by CreatedAt (oldest first)
 	sort.SliceStable(infos, func(i, j int) bool {
 		fi, fj := infos[i].Fleet, infos[j].Fleet
-		// Normalize empty fleet to "default" for sorting
-		if fi == "" {
-			fi = "default"
-		}
-		if fj == "" {
-			fj = "default"
-		}
 		if fi != fj {
-			// "default" always sorts last
-			if fi == "default" {
+			// DefaultFleet always sorts last
+			if fi == DefaultFleet {
 				return false
 			}
-			if fj == "default" {
+			if fj == DefaultFleet {
 				return true
 			}
 			return fi < fj

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -60,6 +60,30 @@ func TestManager_CreateWithOptions_Success(t *testing.T) {
 	}
 }
 
+func TestManager_CreateWithOptions_DefaultFleet(t *testing.T) {
+	mgr, _ := newTestManager(t)
+
+	sess, err := mgr.CreateWithOptions(CreateOptions{WorkDir: "/tmp/fleet-default", Name: "fd"})
+	if err != nil {
+		t.Fatalf("CreateWithOptions failed: %v", err)
+	}
+	if sess.Fleet != DefaultFleet {
+		t.Errorf("Fleet = %q, want %q", sess.Fleet, DefaultFleet)
+	}
+}
+
+func TestManager_CreateWithOptions_ExplicitFleet(t *testing.T) {
+	mgr, _ := newTestManager(t)
+
+	sess, err := mgr.CreateWithOptions(CreateOptions{WorkDir: "/tmp/fleet-named", Name: "fn", Fleet: "backend"})
+	if err != nil {
+		t.Fatalf("CreateWithOptions failed: %v", err)
+	}
+	if sess.Fleet != "backend" {
+		t.Errorf("Fleet = %q, want %q", sess.Fleet, "backend")
+	}
+}
+
 func TestManager_CreateWithOptions_DuplicateWorkDir(t *testing.T) {
 	mgr, _ := newTestManager(t)
 
@@ -168,6 +192,38 @@ func TestManager_List(t *testing.T) {
 	}
 	if infos[1].Name != "second" {
 		t.Errorf("second item Name = %q, want %q", infos[1].Name, "second")
+	}
+}
+
+func TestManager_List_SortedByFleet(t *testing.T) {
+	mgr, _ := newTestManager(t)
+
+	_, err := mgr.CreateWithOptions(CreateOptions{WorkDir: "/tmp/fleet-sort-1", Name: "s1", Fleet: "backend"})
+	if err != nil {
+		t.Fatalf("create s1 failed: %v", err)
+	}
+	_, err = mgr.CreateWithOptions(CreateOptions{WorkDir: "/tmp/fleet-sort-2", Name: "s2"}) // default
+	if err != nil {
+		t.Fatalf("create s2 failed: %v", err)
+	}
+	_, err = mgr.CreateWithOptions(CreateOptions{WorkDir: "/tmp/fleet-sort-3", Name: "s3", Fleet: "alpha"})
+	if err != nil {
+		t.Fatalf("create s3 failed: %v", err)
+	}
+
+	infos := mgr.List()
+	if len(infos) != 3 {
+		t.Fatalf("List returned %d items, want 3", len(infos))
+	}
+	// Expected order: alpha, backend, default (default always last)
+	if infos[0].Fleet != "alpha" {
+		t.Errorf("infos[0].Fleet = %q, want %q", infos[0].Fleet, "alpha")
+	}
+	if infos[1].Fleet != "backend" {
+		t.Errorf("infos[1].Fleet = %q, want %q", infos[1].Fleet, "backend")
+	}
+	if infos[2].Fleet != DefaultFleet {
+		t.Errorf("infos[2].Fleet = %q, want %q", infos[2].Fleet, DefaultFleet)
 	}
 }
 
@@ -984,6 +1040,34 @@ func TestManager_List_WithHostFilter(t *testing.T) {
 	}
 	if hostIDs["host3"] != "local" {
 		t.Errorf("host3 HostID = %q, want %q", hostIDs["host3"], "local")
+	}
+}
+
+func TestNewManager_LoadAll_MigratesEmptyFleet(t *testing.T) {
+	dataDir := t.TempDir()
+	configDir := t.TempDir()
+
+	// Write a session JSON without the fleet field (simulates old data)
+	oldJSON := `{"id":"old-id","name":"old","work_dir":"/tmp/old","created_at":"2025-01-01T00:00:00Z","status":"idle","claude_session_id":"cid"}`
+	if err := os.WriteFile(filepath.Join(dataDir, "old-id.json"), []byte(oldJSON), 0600); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	configMgr, err := config.NewManager(configDir)
+	if err != nil {
+		t.Fatalf("config.NewManager failed: %v", err)
+	}
+	mgr, err := NewManager(dataDir, configDir, configMgr)
+	if err != nil {
+		t.Fatalf("NewManager failed: %v", err)
+	}
+
+	infos := mgr.List()
+	if len(infos) != 1 {
+		t.Fatalf("List returned %d items, want 1", len(infos))
+	}
+	if infos[0].Fleet != DefaultFleet {
+		t.Errorf("Fleet = %q, want %q", infos[0].Fleet, DefaultFleet)
 	}
 }
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -4,6 +4,9 @@ import (
 	"time"
 )
 
+// DefaultFleet is the fleet name used when no fleet is specified.
+const DefaultFleet = "default"
+
 // Status represents the session status
 type Status string
 
@@ -35,7 +38,7 @@ type Session struct {
 	ClaudeSessionStarted bool   `json:"claude_session_started,omitempty"` // Whether the CC session has been started at least once
 
 	// Fleet grouping
-	Fleet string `json:"fleet,omitempty"` // Fleet name for session grouping (empty = "default")
+	Fleet string `json:"fleet"` // Fleet name for session grouping
 
 	// Host info (multi-host support)
 	HostID string `json:"host_id,omitempty"` // Host identifier ("local", "ec2", "docker-dev", etc.)
@@ -66,7 +69,7 @@ type Info struct {
 	ErrorMessage    string    `json:"error_message,omitempty"`
 	ClaudeSessionID string    `json:"claude_session_id,omitempty"` // Claude Code session ID for transcript lookup
 	TmuxWindowName  string    `json:"tmux_window_name,omitempty"`  // tmux window name
-	Fleet           string    `json:"fleet,omitempty"`             // Fleet name for session grouping
+	Fleet           string    `json:"fleet"`                       // Fleet name for session grouping
 	HostID          string    `json:"host_id,omitempty"`           // Host identifier
 
 	// Tracked fields (dynamic, from daemon polling)

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -175,20 +175,20 @@ func TestSession_JSONRoundTrip(t *testing.T) {
 	}
 }
 
-func TestSession_JSONBackwardCompatibility_NoFleet(t *testing.T) {
-	// Existing JSON without fleet field should unmarshal with empty Fleet
-	jsonStr := `{"id":"old-session","name":"old","work_dir":"/tmp","created_at":"2025-01-01T00:00:00Z","status":"idle"}`
-
-	var s Session
-	if err := json.Unmarshal([]byte(jsonStr), &s); err != nil {
-		t.Fatalf("Unmarshal failed: %v", err)
+func TestSession_FleetAlwaysPresentInJSON(t *testing.T) {
+	s := &Session{
+		ID:      "fleet-json-test",
+		Name:    "fj",
+		WorkDir: "/tmp/fj",
+		Fleet:   DefaultFleet,
+		Status:  StatusIdle,
 	}
-
-	if s.Fleet != "" {
-		t.Errorf("Fleet: got %q, want empty string for backward compatibility", s.Fleet)
+	data, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
 	}
-	if s.ID != "old-session" {
-		t.Errorf("ID: got %q, want %q", s.ID, "old-session")
+	if !strings.Contains(string(data), `"fleet":"default"`) {
+		t.Errorf("JSON missing fleet field: %s", data)
 	}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -252,7 +252,7 @@ func (m *Model) getItemsPerPage() int {
 func (m *Model) fleetGroupCount() int {
 	seen := make(map[string]bool)
 	for _, s := range m.sessions {
-		seen[getFleetName(s)] = true
+		seen[s.Fleet] = true
 	}
 	return len(seen)
 }
@@ -1453,25 +1453,14 @@ func getStatusDisplay(status session.Status) (icon, label string, style lipgloss
 	}
 }
 
-// defaultFleetName is used when a session has no fleet assigned.
-const defaultFleetName = "default"
-
 // fleetGroup represents a group of sessions belonging to the same fleet.
 type fleetGroup struct {
 	Name     string
 	Sessions []session.Info
 }
 
-// getFleetName returns the fleet name for a session, defaulting to "default".
-func getFleetName(sess session.Info) string {
-	if sess.Fleet == "" {
-		return defaultFleetName
-	}
-	return sess.Fleet
-}
-
 // groupSessionsByFleet groups sessions by fleet name.
-// Groups are sorted alphabetically, with "default" always last.
+// Groups are sorted alphabetically, with session.DefaultFleet always last.
 // Sessions within each group maintain their original order.
 func groupSessionsByFleet(sessions []session.Info) []fleetGroup {
 	// Collect sessions by fleet
@@ -1480,7 +1469,7 @@ func groupSessionsByFleet(sessions []session.Info) []fleetGroup {
 	seen := make(map[string]bool)
 
 	for _, sess := range sessions {
-		name := getFleetName(sess)
+		name := sess.Fleet
 		if !seen[name] {
 			seen[name] = true
 			fleetNames = append(fleetNames, name)
@@ -1488,12 +1477,12 @@ func groupSessionsByFleet(sessions []session.Info) []fleetGroup {
 		groupMap[name] = append(groupMap[name], sess)
 	}
 
-	// Sort fleet names alphabetically, "default" always last
+	// Sort fleet names alphabetically, DefaultFleet always last
 	sort.SliceStable(fleetNames, func(i, j int) bool {
-		if fleetNames[i] == defaultFleetName {
+		if fleetNames[i] == session.DefaultFleet {
 			return false
 		}
-		if fleetNames[j] == defaultFleetName {
+		if fleetNames[j] == session.DefaultFleet {
 			return true
 		}
 		return fleetNames[i] < fleetNames[j]

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1063,7 +1063,7 @@ func TestGroupSessionsByFleet(t *testing.T) {
 
 	t.Run("default fleet is last", func(t *testing.T) {
 		sessions := []session.Info{
-			{ID: "1", Name: "s1", Fleet: "", CreatedAt: now},
+			{ID: "1", Name: "s1", Fleet: session.DefaultFleet, CreatedAt: now},
 			{ID: "2", Name: "s2", Fleet: "alpha", CreatedAt: now},
 			{ID: "3", Name: "s3", Fleet: "beta", CreatedAt: now},
 		}
@@ -1078,23 +1078,23 @@ func TestGroupSessionsByFleet(t *testing.T) {
 		if groups[1].Name != "beta" {
 			t.Errorf("second group: got %q, want %q", groups[1].Name, "beta")
 		}
-		if groups[2].Name != "default" {
-			t.Errorf("last group: got %q, want %q", groups[2].Name, "default")
+		if groups[2].Name != session.DefaultFleet {
+			t.Errorf("last group: got %q, want %q", groups[2].Name, session.DefaultFleet)
 		}
 	})
 
-	t.Run("empty fleet treated as default", func(t *testing.T) {
+	t.Run("sessions with default fleet group correctly", func(t *testing.T) {
 		sessions := []session.Info{
-			{ID: "1", Name: "s1", Fleet: "", CreatedAt: now},
-			{ID: "2", Name: "s2", Fleet: "", CreatedAt: now},
+			{ID: "1", Name: "s1", Fleet: session.DefaultFleet, CreatedAt: now},
+			{ID: "2", Name: "s2", Fleet: session.DefaultFleet, CreatedAt: now},
 		}
 
 		groups := groupSessionsByFleet(sessions)
 		if len(groups) != 1 {
 			t.Fatalf("expected 1 group, got %d", len(groups))
 		}
-		if groups[0].Name != "default" {
-			t.Errorf("group name: got %q, want %q", groups[0].Name, "default")
+		if groups[0].Name != session.DefaultFleet {
+			t.Errorf("group name: got %q, want %q", groups[0].Name, session.DefaultFleet)
 		}
 		if len(groups[0].Sessions) != 2 {
 			t.Errorf("group sessions: got %d, want 2", len(groups[0].Sessions))
@@ -1120,18 +1120,3 @@ func TestGroupSessionsByFleet(t *testing.T) {
 	})
 }
 
-func TestGetFleetName(t *testing.T) {
-	t.Run("returns fleet name when set", func(t *testing.T) {
-		sess := session.Info{Fleet: "myfleet"}
-		if got := getFleetName(sess); got != "myfleet" {
-			t.Errorf("got %q, want %q", got, "myfleet")
-		}
-	})
-
-	t.Run("returns default when empty", func(t *testing.T) {
-		sess := session.Info{Fleet: ""}
-		if got := getFleetName(sess); got != "default" {
-			t.Errorf("got %q, want %q", got, "default")
-		}
-	})
-}


### PR DESCRIPTION
## 変更内容

fleet フィールドが未指定の場合に各所で `"" → "default"` の変換が散在していた問題を解消する。
保存時点で `"default"` を実値として設定することで、null/空チェックを不要にし一貫性を高める。

### 主な変更

- `session.DefaultFleet = "default"` 定数を追加し全体で参照を統一
- `CreateWithOptions` で fleet 未指定時に `DefaultFleet` を自動設定
- `NewManager` のロード時に `fleet == ""` なら `DefaultFleet` に正規化（lazy migration）
- `Session.Fleet` / `Info.Fleet` の JSON タグから `omitempty` を削除（常に出力）
- TUI の `getFleetName()` ヘルパー・`defaultFleetName` const を削除
- `List()` ソートの空文字列正規化ロジックを削除

### やってないこと

- 既存セッション JSON ファイルへの書き戻し（lazy migration で起動時に補正）
- 後方互換性の維持（意図的に削除）

## 動作確認

```bash
make test  # 全テスト PASS
```

新規テスト:
- `TestManager_CreateWithOptions_DefaultFleet` — 未指定時に "default" が設定される
- `TestManager_CreateWithOptions_ExplicitFleet` — 指定値がそのまま保持される
- `TestManager_List_SortedByFleet` — ソート順（default が最後）
- `TestNewManager_LoadAll_MigratesEmptyFleet` — 旧 JSON ロード時の正規化
- `TestSession_FleetAlwaysPresentInJSON` — fleet が常に JSON に含まれる

🤖 Generated with [Claude Code](https://claude.com/claude-code)