### PR TITLE
fix: show history in dirpicker during remote host loading and allow selection

### DIFF
--- a/internal/tui/dirpicker.go
+++ b/internal/tui/dirpicker.go
@@ -265,12 +265,27 @@ func (m DirPickerModel) Update(msg tea.Msg) (DirPickerModel, tea.Cmd) {
 	// --- Key input ---
 
 	case tea.KeyMsg:
-		// Only allow navigation keys while loading
+		historyLen := len(m.filteredHistory)
+
+		// While loading, only allow history entry navigation and selection
 		if m.loading {
+			switch msg.String() {
+			case "up":
+				if m.cursor > 0 {
+					m.cursor--
+				}
+			case "down":
+				if m.cursor < historyLen-1 {
+					m.cursor++
+				}
+			case "enter":
+				if historyLen > 0 && m.cursor < historyLen {
+					m.selected = true
+					m.result = m.filteredHistory[m.cursor].Path
+				}
+			}
 			return m, nil
 		}
-
-		historyLen := len(m.filteredHistory)
 
 		switch msg.String() {
 		case "enter":
@@ -490,7 +505,28 @@ func (m DirPickerModel) View() string {
 	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#414868"))
 	sectionStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#565f89"))
 
-	// Loading state
+	historyLen := len(m.filteredHistory)
+
+	// History section (always shown, even during loading)
+	if historyLen > 0 {
+		b.WriteString("  " + sectionStyle.Render("── Recently Used "+strings.Repeat("─", sepWidth-18)))
+		b.WriteString("\n")
+		for i, entry := range m.filteredHistory {
+			if i == m.cursor {
+				padded := "▸ " + entry.DisplayPath
+				availWidth := m.width - 4
+				if availWidth > 0 && len(padded) < availWidth {
+					padded += strings.Repeat(" ", availWidth-len(padded))
+				}
+				b.WriteString("  " + selectedStyle.Render(padded))
+			} else {
+				b.WriteString("    " + historyStyle.Render(entry.DisplayPath))
+			}
+			b.WriteString("\n")
+		}
+	}
+
+	// Loading state or directories section
 	if m.loading {
 		b.WriteString("  " + strings.Repeat("─", sepWidth))
 		b.WriteString("\n")
@@ -498,27 +534,6 @@ func (m DirPickerModel) View() string {
 		b.WriteString("  " + spinner + " Loading...")
 		b.WriteString("\n")
 	} else {
-		historyLen := len(m.filteredHistory)
-
-		// History section
-		if historyLen > 0 {
-			b.WriteString("  " + sectionStyle.Render("── Recently Used "+strings.Repeat("─", sepWidth-18)))
-			b.WriteString("\n")
-			for i, entry := range m.filteredHistory {
-				if i == m.cursor {
-					padded := "▸ " + entry.DisplayPath
-					availWidth := m.width - 4
-					if availWidth > 0 && len(padded) < availWidth {
-						padded += strings.Repeat(" ", availWidth-len(padded))
-					}
-					b.WriteString("  " + selectedStyle.Render(padded))
-				} else {
-					b.WriteString("    " + historyStyle.Render(entry.DisplayPath))
-				}
-				b.WriteString("\n")
-			}
-		}
-
 		// Directories section
 		b.WriteString("  " + sectionStyle.Render("── Directories "+strings.Repeat("─", sepWidth-16)))
 		b.WriteString("\n")

--- a/internal/tui/dirpicker_test.go
+++ b/internal/tui/dirpicker_test.go
@@ -803,3 +803,143 @@ func TestDirPickerModel_LeftRightNavigation(t *testing.T) {
 		}
 	})
 }
+
+// --- View() history visibility during loading ---
+
+func TestDirPickerModel_View_HistoryDuringLoading(t *testing.T) {
+	t.Run("shows history section while loading", func(t *testing.T) {
+		m := DirPickerModel{
+			loading: true,
+			width:   80,
+			height:  24,
+		}
+		m.SetHistory([]HistoryEntry{
+			{Path: "/home/user/project", DisplayPath: "/home/user/project"},
+		})
+
+		view := m.View()
+
+		if !strings.Contains(view, "Recently Used") {
+			t.Error("View() should show 'Recently Used' section even while loading")
+		}
+		if !strings.Contains(view, "/home/user/project") {
+			t.Error("View() should show history entry even while loading")
+		}
+		if !strings.Contains(view, "Loading...") {
+			t.Error("View() should still show spinner while loading")
+		}
+	})
+
+	t.Run("shows history section and directories when not loading", func(t *testing.T) {
+		m := DirPickerModel{
+			loading:  false,
+			width:    80,
+			height:   24,
+			filtered: []string{"subdir1", "subdir2"},
+		}
+		m.SetHistory([]HistoryEntry{
+			{Path: "/home/user/project", DisplayPath: "/home/user/project"},
+		})
+
+		view := m.View()
+
+		if !strings.Contains(view, "Recently Used") {
+			t.Error("View() should show 'Recently Used' section when not loading")
+		}
+		if !strings.Contains(view, "/home/user/project") {
+			t.Error("View() should show history entry when not loading")
+		}
+		if !strings.Contains(view, "Directories") {
+			t.Error("View() should show 'Directories' section when not loading")
+		}
+	})
+
+	t.Run("no history section when history is empty during loading", func(t *testing.T) {
+		m := DirPickerModel{
+			loading: true,
+			width:   80,
+			height:  24,
+		}
+
+		view := m.View()
+
+		if strings.Contains(view, "Recently Used") {
+			t.Error("View() should not show 'Recently Used' section when history is empty")
+		}
+		if !strings.Contains(view, "Loading...") {
+			t.Error("View() should show spinner when loading with no history")
+		}
+	})
+}
+
+// --- Update() history selection during loading ---
+
+func TestDirPickerModel_Update_HistorySelectionDuringLoading(t *testing.T) {
+	t.Run("enter selects history entry while loading", func(t *testing.T) {
+		m := DirPickerModel{
+			loading: true,
+			cursor:  0,
+		}
+		m.SetHistory([]HistoryEntry{
+			{Path: "/home/user/project", DisplayPath: "/home/user/project"},
+		})
+
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+		if !updated.selected {
+			t.Error("Enter should select history entry while loading")
+		}
+		if updated.result != "/home/user/project" {
+			t.Errorf("result = %q, want %q", updated.result, "/home/user/project")
+		}
+	})
+
+	t.Run("up/down moves cursor within history while loading", func(t *testing.T) {
+		m := DirPickerModel{
+			loading: true,
+			cursor:  0,
+		}
+		m.SetHistory([]HistoryEntry{
+			{Path: "/home/user/project1", DisplayPath: "/home/user/project1"},
+			{Path: "/home/user/project2", DisplayPath: "/home/user/project2"},
+		})
+
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+		if updated.cursor != 1 {
+			t.Errorf("cursor after down = %d, want 1", updated.cursor)
+		}
+
+		updated2, _ := updated.Update(tea.KeyMsg{Type: tea.KeyUp})
+		if updated2.cursor != 0 {
+			t.Errorf("cursor after up = %d, want 0", updated2.cursor)
+		}
+	})
+
+	t.Run("down does not exceed history length while loading", func(t *testing.T) {
+		m := DirPickerModel{
+			loading: true,
+			cursor:  0,
+		}
+		m.SetHistory([]HistoryEntry{
+			{Path: "/home/user/project", DisplayPath: "/home/user/project"},
+		})
+
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+		if updated.cursor != 0 {
+			t.Errorf("cursor should stay at 0 when only 1 history entry, got %d", updated.cursor)
+		}
+	})
+
+	t.Run("enter does nothing when history is empty while loading", func(t *testing.T) {
+		m := DirPickerModel{
+			loading: true,
+			cursor:  0,
+		}
+
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+		if updated.selected {
+			t.Error("Enter should not select when history is empty while loading")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- `View()` の描画ロジックを修正し、SSH ディレクトリのロード中（スピナー表示中）でも「Recently Used」セクションを常に表示するようにした
- `Update()` のロード中ガードを修正し、`up`/`down` によるカーソル移動と `enter` による履歴選択を可能にした（従来はすべてのキー入力を無視していた）
- テストを追加（View の履歴表示確認 3 ケース、Update のロード中選択確認 4 ケース）

Fixes #12

## Test plan

- [x] `make test` 全件 PASS
- [ ] SSH リモートホスト選択後のロード中に「Recently Used」が表示されること（手動確認）
- [ ] ロード中に履歴エントリを `enter` で選択できること（手動確認）
- [ ] ロード完了後も履歴セクションが表示されること（手動確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)