### PR TITLE
fix: start remote daemon via login shell to resolve PATH issues

### DIFF
--- a/internal/host/bootstrap.go
+++ b/internal/host/bootstrap.go
@@ -53,8 +53,10 @@ func validatePath(s string) error {
 	return nil
 }
 
-// StartSlaveCommand generates a command to start the slave daemon on a remote host
-func StartSlaveCommand(hostConfig config.HostConfig, opts ...BootstrapOptions) *exec.Cmd {
+// startSlaveCommand generates a command to start the slave daemon on a remote host.
+// Inputs must be validated before calling (use validatePath / ValidateIdentifier).
+// Use StartSlave which performs validation automatically.
+func startSlaveCommand(hostConfig config.HostConfig, opts ...BootstrapOptions) *exec.Cmd {
 	socketPath := hostConfig.SocketPath
 	if socketPath == "" {
 		socketPath = defaultRemoteSocketPath
@@ -71,10 +73,14 @@ func StartSlaveCommand(hostConfig config.HostConfig, opts ...BootstrapOptions) *
 		// - ControlMaster=no: avoid conflicts with existing ControlMaster
 		// - ClearAllForwardings=yes: suppress LocalForward/RemoteForward from ssh_config
 		//   (bootstrap is a one-shot command execution, no forwarding needed)
-		args := make([]string, 0, len(hostConfig.SSHOpts)+6)
+		args := make([]string, 0, len(hostConfig.SSHOpts)+6) // 4 fixed opts + host + shellCmd
 		args = append(args, "-o", "ControlMaster=no", "-o", "ClearAllForwardings=yes")
 		args = append(args, hostConfig.SSHOpts...)
-		args = append(args, hostConfig.Host, remoteCmd)
+		// Use login shell so ~/.bash_profile / ~/.zprofile are sourced and PATH is resolved.
+		// ${SHELL:-/bin/sh} falls back to /bin/sh if $SHELL is unset on the remote.
+		// Note: remoteCmd must not contain single quotes; guaranteed by validatePath/ValidateIdentifier.
+		shellCmd := `${SHELL:-/bin/sh} -l -c '` + remoteCmd + `'`
+		args = append(args, hostConfig.Host, shellCmd)
 		return exec.Command("ssh", args...)
 	case "docker":
 		return exec.Command("docker", "exec", hostConfig.Container, "sh", "-c", remoteCmd)
@@ -86,7 +92,12 @@ func StartSlaveCommand(hostConfig config.HostConfig, opts ...BootstrapOptions) *
 // StartSlave starts the slave daemon on a remote host and returns the result.
 // Returns an error if ccvalet is not installed on the remote host.
 func StartSlave(hostConfig config.HostConfig, opts ...BootstrapOptions) error {
-	// Validate peer options before building the shell command (prevent injection)
+	// Validate all inputs before building the shell command (prevent injection)
+	if hostConfig.SocketPath != "" {
+		if err := validatePath(hostConfig.SocketPath); err != nil {
+			return fmt.Errorf("invalid socket path: %w", err)
+		}
+	}
 	if len(opts) > 0 && opts[0].PeerSocketPath != "" && opts[0].PeerHostID != "" {
 		if err := validatePath(opts[0].PeerSocketPath); err != nil {
 			return fmt.Errorf("invalid peer socket path: %w", err)
@@ -96,7 +107,7 @@ func StartSlave(hostConfig config.HostConfig, opts ...BootstrapOptions) error {
 		}
 	}
 
-	cmd := StartSlaveCommand(hostConfig, opts...)
+	cmd := startSlaveCommand(hostConfig, opts...)
 	if cmd == nil {
 		return fmt.Errorf("unsupported host type: %s", hostConfig.Type)
 	}

--- a/internal/host/bootstrap_test.go
+++ b/internal/host/bootstrap_test.go
@@ -99,7 +99,7 @@ func TestStartSlaveCommand(t *testing.T) {
 			Type: "ssh",
 			Host: "myhost",
 		}
-		cmd := StartSlaveCommand(hc)
+		cmd := startSlaveCommand(hc)
 		if cmd == nil {
 			t.Fatal("expected non-nil command")
 		}
@@ -110,7 +110,7 @@ func TestStartSlaveCommand(t *testing.T) {
 			"-o", "ControlMaster=no",
 			"-o", "ClearAllForwardings=yes",
 			"myhost",
-			"ccvalet daemon start --socket ~/.ccvalet/run/daemon.sock",
+			`${SHELL:-/bin/sh} -l -c 'ccvalet daemon start --socket ~/.ccvalet/run/daemon.sock'`,
 		}
 		if len(cmd.Args) != len(wantArgs) {
 			t.Fatalf("args length = %d, want %d\ngot:  %v\nwant: %v", len(cmd.Args), len(wantArgs), cmd.Args, wantArgs)
@@ -128,12 +128,12 @@ func TestStartSlaveCommand(t *testing.T) {
 			Host:       "myhost",
 			SocketPath: "/tmp/custom.sock",
 		}
-		cmd := StartSlaveCommand(hc)
+		cmd := startSlaveCommand(hc)
 		if cmd == nil {
 			t.Fatal("expected non-nil command")
 		}
 
-		wantRemoteCmd := "ccvalet daemon start --socket /tmp/custom.sock"
+		wantRemoteCmd := `${SHELL:-/bin/sh} -l -c 'ccvalet daemon start --socket /tmp/custom.sock'`
 		// The remote command is the last element of Args
 		lastArg := cmd.Args[len(cmd.Args)-1]
 		if lastArg != wantRemoteCmd {
@@ -147,7 +147,7 @@ func TestStartSlaveCommand(t *testing.T) {
 			Host:    "myhost",
 			SSHOpts: []string{"-p", "2222", "-i", "/path/to/key"},
 		}
-		cmd := StartSlaveCommand(hc)
+		cmd := startSlaveCommand(hc)
 		if cmd == nil {
 			t.Fatal("expected non-nil command")
 		}
@@ -158,7 +158,7 @@ func TestStartSlaveCommand(t *testing.T) {
 			"-o", "ClearAllForwardings=yes",
 			"-p", "2222", "-i", "/path/to/key",
 			"myhost",
-			"ccvalet daemon start --socket ~/.ccvalet/run/daemon.sock",
+			`${SHELL:-/bin/sh} -l -c 'ccvalet daemon start --socket ~/.ccvalet/run/daemon.sock'`,
 		}
 		if len(cmd.Args) != len(wantArgs) {
 			t.Fatalf("args length = %d, want %d\ngot:  %v\nwant: %v", len(cmd.Args), len(wantArgs), cmd.Args, wantArgs)
@@ -175,7 +175,7 @@ func TestStartSlaveCommand(t *testing.T) {
 			Type:      "docker",
 			Container: "my-container",
 		}
-		cmd := StartSlaveCommand(hc)
+		cmd := startSlaveCommand(hc)
 		if cmd == nil {
 			t.Fatal("expected non-nil command")
 		}
@@ -198,7 +198,7 @@ func TestStartSlaveCommand(t *testing.T) {
 		hc := config.HostConfig{
 			Type: "unknown",
 		}
-		cmd := StartSlaveCommand(hc)
+		cmd := startSlaveCommand(hc)
 		if cmd != nil {
 			t.Errorf("expected nil for unknown type, got %v", cmd)
 		}
@@ -210,14 +210,24 @@ func TestStartSlaveCommand(t *testing.T) {
 			PeerSocketPath: "/tmp/ccvalet-peers/mac/daemon.sock",
 			PeerHostID:     "mac",
 		}
-		cmd := StartSlaveCommand(hc, opts)
+		cmd := startSlaveCommand(hc, opts)
 		if cmd == nil {
 			t.Fatal("expected non-nil command")
 		}
-		lastArg := cmd.Args[len(cmd.Args)-1]
-		want := "ccvalet daemon start --socket ~/.ccvalet/run/daemon.sock --peer-socket /tmp/ccvalet-peers/mac/daemon.sock --peer-id mac"
-		if lastArg != want {
-			t.Errorf("remote command = %q, want %q", lastArg, want)
+		wantArgs := []string{
+			"ssh",
+			"-o", "ControlMaster=no",
+			"-o", "ClearAllForwardings=yes",
+			"myhost",
+			`${SHELL:-/bin/sh} -l -c 'ccvalet daemon start --socket ~/.ccvalet/run/daemon.sock --peer-socket /tmp/ccvalet-peers/mac/daemon.sock --peer-id mac'`,
+		}
+		if len(cmd.Args) != len(wantArgs) {
+			t.Fatalf("args length = %d, want %d\ngot:  %v\nwant: %v", len(cmd.Args), len(wantArgs), cmd.Args, wantArgs)
+		}
+		for i, arg := range wantArgs {
+			if cmd.Args[i] != arg {
+				t.Errorf("Args[%d] = %q, want %q", i, cmd.Args[i], arg)
+			}
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- SSH経由でリモートデーモン起動時に `ccvalet: command not found` になる問題を修正
- `${SHELL:-/bin/sh} -l -c '...'` でラップしてloginシェル経由で実行、`.bash_profile` / `.zprofile` のPATHを解決
- `StartSlaveCommand` をunexported化（`startSlaveCommand`）し、バリデーションを `StartSlave` 経由に統一
- `hostConfig.SocketPath` のバリデーションを `StartSlave` に追加

## Test plan

- [ ] `go test ./internal/host/...` が全件PASS
- [ ] SSHホストで `ccvalet daemon start` が `/usr/local/bin` 等のカスタムPATHでも正常起動すること

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)