### PR TITLE
fix: auto-reconnect remote daemons after SSH connection drop

### DIFF
--- a/internal/daemon/integration_test.go
+++ b/internal/daemon/integration_test.go
@@ -1068,7 +1068,7 @@ func TestIntegration_ListWithHostID_VisitedPropagated(t *testing.T) {
 
 // visitedCaptureMock captures the visited argument for inspection in tests.
 type visitedCaptureMock struct {
-	captureList func([]string)
+	captureList  func([]string)
 	captureNotif func([]string)
 }
 
@@ -1181,8 +1181,15 @@ func TestReconnectDeadTunnels_DeadSSHHost(t *testing.T) {
 		t.Error("reconnecting[ec2] should be true while goroutine is running")
 	}
 
-	// Second call must be a no-op while reconnect is in progress.
+	// Second call must be a no-op while reconnect is in progress:
+	// reconnecting map should still have exactly one entry.
 	server.reconnectDeadTunnels()
+	server.reconnectingMu.Lock()
+	count := len(server.reconnecting)
+	server.reconnectingMu.Unlock()
+	if count != 1 {
+		t.Errorf("reconnecting map should have 1 entry after no-op call, got %d", count)
+	}
 }
 
 func TestWatchRemoteConnections_StopsOnClose(t *testing.T) {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -32,16 +32,16 @@ const remoteReconnectInterval = 30 * time.Second
 
 // Server is the daemon server
 type Server struct {
-	socketPath   string
-	hostID       string // This daemon's host ID (e.g., "mac", "ec2"; default "local")
-	manager      *session.Manager
-	configMgr    *config.Manager
-	stateMgr     *config.StateManager
-	listener     net.Listener
+	socketPath     string
+	hostID         string // This daemon's host ID (e.g., "mac", "ec2"; default "local")
+	manager        *session.Manager
+	configMgr      *config.Manager
+	stateMgr       *config.StateManager
+	listener       net.Listener
 	createMu       sync.Mutex      // Mutual exclusion for session creation
 	hostRegistry   *host.Registry  // Multi-host management
 	tunnelMgr      *tunnel.Manager // SSH tunnel management
-	stopPoll       chan struct{}    // Signal to stop background goroutines; initialized once in initRemoteSlaves, never reassigned
+	stopPoll       chan struct{}   // Signal to stop background goroutines; initialized once in initRemoteSlaves, never reassigned
 	reconnectingMu sync.Mutex      // Protects reconnecting map
 	reconnecting   map[string]bool // Tracks hosts with a reconnect goroutine in progress
 }
@@ -154,7 +154,7 @@ func (s *Server) Start() error {
 
 // Stop stops the daemon server
 func (s *Server) Stop() {
-	// Stop remote notification polling
+	// Stop background goroutines (remote notifications and connection watcher)
 	if s.stopPoll != nil {
 		close(s.stopPoll)
 	}
@@ -610,8 +610,8 @@ func (s *Server) initRemoteSlaves() {
 
 // connectRemoteSlave runs the full 3-step connection sequence for one remote host:
 // start slave daemon, open tunnel, register client.
-// Safe to call when already connected: StartSlave is idempotent, tunnelMgr.Open
-// returns the existing socket if the tunnel is still alive.
+// Called during initial setup and reconnect. StartSlave is idempotent;
+// tunnelMgr.Open returns the existing socket if the tunnel is still alive.
 func (s *Server) connectRemoteSlave(h *host.Host) error {
 	peerSocketPath := filepath.Join(tunnel.PeerSocketDir, s.hostID, "daemon.sock")
 	bootstrapOpts := host.BootstrapOptions{


### PR DESCRIPTION
## 概要

SSH接続が切れた後、ローカルdaemonを再起動せずにリモートセッションが自動復帰するようにした。

**問題:** SSH接続断後、`hostRegistry` には古い `RemoteClient` が残るが、トンネルプロセスが死んでいるため `handleList()` が失敗しリモートセッションがTUIに表示されなくなる。回復にはローカルdaemonの再起動が必要だった。

**修正:** バックグラウンドgoroutine `watchRemoteConnections` を追加し、30秒ごとにSSHトンネルの生存確認 → 死んでいれば自動再接続する。

## 変更内容

- `connectRemoteSlave(h)` — `initRemoteSlaves()` のループ内ロジックを独立メソッドに抽出（3ステップ: slave起動 → トンネル開通 → クライアント登録）
- `watchRemoteConnections()` — 30秒ごとに `reconnectDeadTunnels()` を呼ぶ watcher goroutine
- `reconnectDeadTunnels()` — SSH typeのホストのみ `tunnelMgr.IsAlive()` でチェックし、死んでいれば再接続
- `reconnecting map[string]bool` + mutex — 同一ホストへの多重再接続goroutineを防止
- Docker hostはスキップ（ボリュームマウント方式のため再接続不要）

## やってないこと

- 再接続間隔の設定化（現在は30秒固定）
- TUIへの再接続状態表示

## 動作確認

```bash
# ビルド確認
make build

# テスト（race detector含む）
make test-race
```

手動確認手順:
1. `ccvalet daemon start` でローカル起動
2. リモートセッションがTUIに表示されることを確認
3. SSHトンネルプロセスを強制終了: `kill -9 $(pgrep -f "ssh.*ccvalet")`
4. TUIからリモートセッションが消えることを確認
5. 30秒以内に自動再接続されリモートセッションが再表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)