### PR TITLE
fix: sort session list by fleet/CreatedAt after merging remote sessions

### DIFF
--- a/internal/daemon/integration_test.go
+++ b/internal/daemon/integration_test.go
@@ -1128,6 +1128,117 @@ func TestIntegration_ForwardedRequestHostIDCleared(t *testing.T) {
 	}
 }
 
+// TestIntegration_HandleList_SortedByFleet verifies that handleList() returns sessions
+// sorted by fleet (alphabetically, "default" last) then by CreatedAt, even when remote
+// sessions are mixed in from multiple hosts.
+func TestIntegration_HandleList_SortedByFleet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	now := time.Now()
+
+	tests := []struct {
+		name          string
+		remoteSessions []session.Info
+		wantFleets    []string // expected Fleet order in result
+	}{
+		{
+			name: "mixed fleet local and remote sessions",
+			remoteSessions: []session.Info{
+				// Remote sessions use past timestamps so local sessions (created after now)
+				// are always later within the same fleet.
+				{ID: "remote-work-1", Fleet: "work", CreatedAt: now.Add(-10 * time.Second)},
+				{ID: "remote-default-1", Fleet: session.DefaultFleet, CreatedAt: now.Add(-5 * time.Second)},
+			},
+			wantFleets: []string{"work", "work", session.DefaultFleet, session.DefaultFleet},
+		},
+		{
+			name:           "remote returns empty",
+			remoteSessions: []session.Info{},
+			wantFleets:     []string{"work", session.DefaultFleet},
+		},
+		{
+			name: "all same fleet remote earlier than local",
+			remoteSessions: []session.Info{
+				{ID: "remote-work-1", Fleet: "work", CreatedAt: now.Add(-20 * time.Second)},
+			},
+			wantFleets: []string{"work", "work", session.DefaultFleet},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server, client := setupTestServer(t)
+
+			// Create local sessions: one "work", one "default" (different dirs to avoid conflict)
+			tmpDir := shortTempDir(t)
+			_, err := client.NewWithOptions(NewOptions{WorkDir: tmpDir + "/work", Fleet: "work", Start: false})
+			if err != nil {
+				t.Fatalf("NewWithOptions(work): %v", err)
+			}
+
+			_, err = client.NewWithOptions(NewOptions{WorkDir: tmpDir + "/def", Fleet: session.DefaultFleet, Start: false})
+			if err != nil {
+				t.Fatalf("NewWithOptions(default): %v", err)
+			}
+
+			// Register a mock remote host returning tc.remoteSessions
+			mock := &listOnlyMock{sessions: tc.remoteSessions}
+			registry := host.NewRegistry([]config.HostConfig{{ID: "remote1", Type: "ssh"}})
+			registry.SetClient("remote1", mock)
+			server.hostRegistry = registry
+
+			infos, err := client.List()
+			if err != nil {
+				t.Fatalf("List: %v", err)
+			}
+
+			// Verify fleet ordering: non-default fleets before default,
+			// and within the same fleet sessions are in CreatedAt ascending order.
+			for i := 0; i < len(infos)-1; i++ {
+				fi, fj := infos[i].Fleet, infos[i+1].Fleet
+				if fi == session.DefaultFleet && fj != session.DefaultFleet {
+					t.Errorf("sort violation at [%d,%d]: default fleet before non-default (%q, %q)", i, i+1, fi, fj)
+				}
+				if fi == fj {
+					if infos[i].CreatedAt.After(infos[i+1].CreatedAt) {
+						t.Errorf("sort violation at [%d,%d]: same fleet but CreatedAt not ascending (%v > %v)", i, i+1, infos[i].CreatedAt, infos[i+1].CreatedAt)
+					}
+				}
+			}
+
+			// Verify fleets match expected sequence if specified
+			if len(tc.wantFleets) > 0 {
+				if len(infos) != len(tc.wantFleets) {
+					t.Fatalf("want %d sessions (wantFleets=%v), got %d: %v", len(tc.wantFleets), tc.wantFleets, len(infos), infos)
+				}
+				for i, info := range infos {
+					if info.Fleet != tc.wantFleets[i] {
+						t.Errorf("infos[%d].Fleet = %q, want %q", i, info.Fleet, tc.wantFleets[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+// listOnlyMock is a HostClient that returns a fixed session list.
+type listOnlyMock struct {
+	sessions []session.Info
+}
+
+func (m *listOnlyMock) IsRunning() bool { return true }
+func (m *listOnlyMock) ListWithHostID(_ []string) ([]session.Info, error) {
+	return m.sessions, nil
+}
+func (m *listOnlyMock) NotificationHistoryWithHostID(_ []string) ([]notify.Entry, error) {
+	return nil, nil
+}
+func (m *listOnlyMock) SendRaw(_ string, _, _ []byte) ([]byte, error) {
+	return []byte(`{"success":true}`), nil
+}
+
 // rawCaptureMock captures SendRaw calls for inspection.
 type rawCaptureMock struct {
 	capture func(action string, data []byte)

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -372,7 +372,7 @@ func (s *Server) handleList(visited []string) Response {
 		}
 	}
 
-	// Return only local if no host registry
+	// Return only local if no host registry; manager.List() is already sorted.
 	if s.hostRegistry == nil {
 		data, _ := json.Marshal(localSessions)
 		return Response{Success: true, Data: data}
@@ -413,6 +413,10 @@ func (s *Server) handleList(visited []string) Response {
 			allSessions = append(allSessions, result.sessions...)
 		}
 	}
+
+	// Re-sort after merging remote sessions; manager.List() is already sorted
+	// but remote results arrive in arbitrary order.
+	session.SortInfos(allSessions)
 
 	data, _ := json.Marshal(allSessions)
 	return Response{Success: true, Data: data}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -256,21 +255,7 @@ func (m *Manager) List() []Info {
 		}
 	}
 
-	// Sort by Fleet (alphabetically, "default" last), then by CreatedAt (oldest first)
-	sort.SliceStable(infos, func(i, j int) bool {
-		fi, fj := infos[i].Fleet, infos[j].Fleet
-		if fi != fj {
-			// DefaultFleet always sorts last
-			if fi == DefaultFleet {
-				return false
-			}
-			if fj == DefaultFleet {
-				return true
-			}
-			return fi < fj
-		}
-		return infos[i].CreatedAt.Before(infos[j].CreatedAt)
-	})
+	SortInfos(infos)
 
 	return infos
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"sort"
 	"time"
 )
 
@@ -79,6 +80,26 @@ type Info struct {
 	// Last messages from transcript
 	LastUserMessage      string `json:"last_user_message,omitempty"`      // Last user message content (truncated)
 	LastAssistantMessage string `json:"last_assistant_message,omitempty"` // Last assistant message content (truncated)
+}
+
+// SortInfos sorts a slice of Info by Fleet (lexicographically, DefaultFleet last),
+// then by CreatedAt (oldest first). This is the canonical sort order used
+// throughout the application. This function sorts the slice in-place.
+func SortInfos(infos []Info) {
+	sort.SliceStable(infos, func(i, j int) bool {
+		fi, fj := infos[i].Fleet, infos[j].Fleet
+		if fi != fj {
+			// DefaultFleet always sorts last
+			if fi == DefaultFleet {
+				return false
+			}
+			if fj == DefaultFleet {
+				return true
+			}
+			return fi < fj
+		}
+		return infos[i].CreatedAt.Before(infos[j].CreatedAt)
+	})
 }
 
 // ToInfo converts Session to Info

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -247,3 +247,92 @@ func TestSession_JSONOmitsRuntimeFields(t *testing.T) {
 		}
 	}
 }
+
+func TestSortInfos(t *testing.T) {
+	t0 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := t0.Add(time.Second)
+	t2 := t0.Add(2 * time.Second)
+
+	tests := []struct {
+		name  string
+		input []Info
+		want  []string // expected ID order
+	}{
+		{
+			name:  "empty slice",
+			input: []Info{},
+			want:  []string{},
+		},
+		{
+			name:  "single element",
+			input: []Info{{ID: "a", Fleet: "work", CreatedAt: t0}},
+			want:  []string{"a"},
+		},
+		{
+			name: "default fleet sorts last",
+			input: []Info{
+				{ID: "d", Fleet: DefaultFleet, CreatedAt: t0},
+				{ID: "w", Fleet: "work", CreatedAt: t0},
+			},
+			want: []string{"w", "d"},
+		},
+		{
+			name: "non-default fleets sorted alphabetically",
+			input: []Info{
+				{ID: "z", Fleet: "zz", CreatedAt: t0},
+				{ID: "a", Fleet: "aa", CreatedAt: t0},
+				{ID: "d", Fleet: DefaultFleet, CreatedAt: t0},
+			},
+			want: []string{"a", "z", "d"},
+		},
+		{
+			name: "three non-default fleets sorted lexicographically",
+			input: []Info{
+				{ID: "c", Fleet: "cc", CreatedAt: t0},
+				{ID: "a", Fleet: "aa", CreatedAt: t0},
+				{ID: "b", Fleet: "bb", CreatedAt: t0},
+				{ID: "d", Fleet: DefaultFleet, CreatedAt: t0},
+			},
+			want: []string{"a", "b", "c", "d"},
+		},
+		{
+			name: "same fleet sorted by CreatedAt ascending",
+			input: []Info{
+				{ID: "new", Fleet: "work", CreatedAt: t2},
+				{ID: "old", Fleet: "work", CreatedAt: t0},
+				{ID: "mid", Fleet: "work", CreatedAt: t1},
+			},
+			want: []string{"old", "mid", "new"},
+		},
+		{
+			name: "SliceStable preserves original order for equal CreatedAt",
+			input: []Info{
+				{ID: "first", Fleet: "work", CreatedAt: t0},
+				{ID: "second", Fleet: "work", CreatedAt: t0},
+			},
+			want: []string{"first", "second"},
+		},
+		{
+			name: "only default fleet",
+			input: []Info{
+				{ID: "b", Fleet: DefaultFleet, CreatedAt: t1},
+				{ID: "a", Fleet: DefaultFleet, CreatedAt: t0},
+			},
+			want: []string{"a", "b"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			SortInfos(tc.input)
+			if len(tc.input) != len(tc.want) {
+				t.Fatalf("len = %d, want %d", len(tc.input), len(tc.want))
+			}
+			for i, info := range tc.input {
+				if info.ID != tc.want[i] {
+					t.Errorf("[%d] ID = %q, want %q", i, info.ID, tc.want[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 概要

マルチホスト環境で TUI を起動した際に、カーソル位置と視覚的な行位置がズレるバグを修正した。

### 原因

`handleList()` がリモートセッションを `append` するだけで結合後のソートを行っていなかった。
結果として `m.sessions` がローカルファースト順になる一方、TUI の描画は `groupSessionsByFleet()` で fleet 順にリグループするため、カーソルインデックスと表示行がズレていた。

### 変更内容

- `internal/session/session.go` — `SortInfos()` ヘルパーを新設（`manager.List()` と `handleList()` で共有）
- `internal/session/manager.go` — インラインソートを `SortInfos()` 呼び出しに置換（DRY化）
- `internal/daemon/server.go` — `handleList()` の末尾にリモート結合後のソートを追加
- `internal/session/session_test.go` — `TestSortInfos` ユニットテスト追加（8ケース）
- `internal/daemon/integration_test.go` — `TestIntegration_HandleList_SortedByFleet` 統合テスト追加（3ケース）

### やっていないこと

- TUI 側（`model.go`）の変更は不要のため対応なし

## 動作確認

```bash
make test
make test-race
```

全テスト PASS、data race なし。

Closes #22