### PR TITLE
feat: add init command to generate default config.yaml

### DIFF
--- a/cmd/ccvalet/cmd/init.go
+++ b/cmd/ccvalet/cmd/init.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+// configTemplate is the default config.yaml written by `ccvalet init`
+const configTemplate = `# ccvalet configuration
+# See https://github.com/takaaki-s/claude-code-valet for details
+
+# Customize keybindings (defaults are used when omitted)
+keybindings:
+  # Session list view
+  up: ["up", "k"]
+  down: ["down", "j"]
+  attach: ["enter"]
+  new: ["n"]
+  kill: ["x"]
+  delete: ["d"]
+  refresh: ["r"]
+  search: ["/"]
+  vscode: ["v"]
+  notifications: ["!"]
+  quit: ["q", "ctrl+c"]
+  help: ["?"]
+  # Session creation form
+  next_field: ["tab"]
+  prev_field: ["shift+tab"]
+  submit: ["enter"]
+  cancel_form: ["esc"]
+  # While attached
+  # Supported keys: ctrl+^, ctrl+], ctrl+\, ctrl+g
+  detach: ["ctrl+]"]
+`
+
+var forceInit bool
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Initialize ccvalet configuration",
+	Long: `Create the ccvalet configuration directory and a default config.yaml.
+
+If config.yaml already exists, this command does nothing unless --force is specified.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		configDir := getConfigDir()
+		configFile := filepath.Join(configDir, "config.yaml")
+
+		if err := os.MkdirAll(configDir, 0755); err != nil {
+			return fmt.Errorf("failed to create config directory: %w", err)
+		}
+
+		if !forceInit {
+			if _, err := os.Stat(configFile); err == nil {
+				fmt.Printf("Config already exists: %s\n", configFile)
+				fmt.Println("Use --force to overwrite.")
+				return nil
+			}
+		}
+
+		if err := os.WriteFile(configFile, []byte(configTemplate), 0644); err != nil {
+			return fmt.Errorf("failed to write config: %w", err)
+		}
+
+		fmt.Printf("Created: %s\n", configFile)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(initCmd)
+	initCmd.Flags().BoolVar(&forceInit, "force", false, "Overwrite existing config.yaml")
+}

--- a/cmd/ccvalet/cmd/init_test.go
+++ b/cmd/ccvalet/cmd/init_test.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInitCmd_CreatesConfig(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "config.yaml")
+
+	// Temporarily override getConfigDir via the flag mechanism
+	// by directly testing the file creation logic
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(configFile, []byte(configTemplate), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != configTemplate {
+		t.Errorf("config content mismatch")
+	}
+}
+
+func TestInitCmd_NoOverwriteWithoutForce(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "config.yaml")
+
+	original := "# original\n"
+	if err := os.WriteFile(configFile, []byte(original), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// Simulate the no-force path: file exists, don't overwrite
+	if _, err := os.Stat(configFile); err == nil {
+		// file exists — skip write (matches initCmd logic when !forceInit)
+		data, _ := os.ReadFile(configFile)
+		if string(data) != original {
+			t.Errorf("file should not have been overwritten")
+		}
+	}
+}
+
+func TestInitCmd_OverwriteWithForce(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "config.yaml")
+
+	if err := os.WriteFile(configFile, []byte("# old\n"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// Simulate force overwrite
+	if err := os.WriteFile(configFile, []byte(configTemplate), 0644); err != nil {
+		t.Fatalf("WriteFile force: %v", err)
+	}
+
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != configTemplate {
+		t.Errorf("expected template content after force overwrite")
+	}
+}
+
+func TestConfigTemplate_ContainsExpectedKeys(t *testing.T) {
+	keys := []string{
+		"keybindings:",
+		"up:",
+		"down:",
+		"attach:",
+		"detach:",
+		"quit:",
+	}
+	for _, key := range keys {
+		found := false
+		for i := 0; i < len(configTemplate)-len(key); i++ {
+			if configTemplate[i:i+len(key)] == key {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("configTemplate missing key: %s", key)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `ccvalet init` コマンドを追加
- `~/.ccvalet/config.yaml` をコメント付きデフォルトテンプレートで生成
- `--force` フラグで既存ファイルの上書きに対応

## Test plan

- [ ] `ccvalet init` で `~/.ccvalet/config.yaml` が生成されることを確認
- [ ] 既存ファイルがある場合、`--force` なしでは上書きされないことを確認
- [ ] `--force` 指定時に上書きされることを確認
- [ ] `go test ./cmd/ccvalet/cmd/` が通ること