### PR TITLE
fix: forward dir-history request to remote slave daemon

### DIFF
--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -828,6 +828,17 @@ func (s *Server) handleDirHistory(data json.RawMessage) Response {
 		req.MaxEntries = 5
 	}
 
+	// If request is for a remote host, forward to the slave daemon.
+	// The slave stores its history as HostID="local", so clear HostID before forwarding.
+	if req.HostID != "local" {
+		forwardReq := struct {
+			HostID     string `json:"host_id"`
+			MaxEntries int    `json:"max_entries"`
+		}{HostID: "local", MaxEntries: req.MaxEntries}
+		forwardData, _ := json.Marshal(forwardReq)
+		return s.forwardToHost(req.HostID, Request{Action: "dir-history", Data: forwardData})
+	}
+
 	entries := s.stateMgr.GetDirHistory(req.HostID, req.MaxEntries)
 	respData, _ := json.Marshal(entries)
 	return Response{Success: true, Data: respData}


### PR DESCRIPTION
## Summary

- リモートホストのファイルピッカーにディレクトリ履歴が表示されない問題を修正
- `handleDirHistory` が `HostID != "local"` の場合にマスターのローカル state.yaml のみ参照していたのが原因
- スレーブはセッション作成時のディレクトリ履歴を `HostID="local"` で自身の state.yaml に記録しているため、マスター側では見つからなかった
- `forwardToHost` を使ってスレーブに転送し、転送時に `HostID="local"` にクリアすることで修正

## Test plan

- [ ] リモートスレーブでセッションを作成
- [ ] ファイルピッカーを開き、リモートホスト選択時に履歴が表示されることを確認
- [ ] ローカルホストの履歴表示が引き続き正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)