### PR TITLE
revert: PR #19 login shell wrapping for remote daemon start

### DIFF
--- a/internal/host/bootstrap.go
+++ b/internal/host/bootstrap.go
@@ -53,10 +53,8 @@ func validatePath(s string) error {
 	return nil
 }
 
-// startSlaveCommand generates a command to start the slave daemon on a remote host.
-// Inputs must be validated before calling (use validatePath / ValidateIdentifier).
-// Use StartSlave which performs validation automatically.
-func startSlaveCommand(hostConfig config.HostConfig, opts ...BootstrapOptions) *exec.Cmd {
+// StartSlaveCommand generates a command to start the slave daemon on a remote host
+func StartSlaveCommand(hostConfig config.HostConfig, opts ...BootstrapOptions) *exec.Cmd {
 	socketPath := hostConfig.SocketPath
 	if socketPath == "" {
 		socketPath = defaultRemoteSocketPath
@@ -73,14 +71,10 @@ func startSlaveCommand(hostConfig config.HostConfig, opts ...BootstrapOptions) *
 		// - ControlMaster=no: avoid conflicts with existing ControlMaster
 		// - ClearAllForwardings=yes: suppress LocalForward/RemoteForward from ssh_config
 		//   (bootstrap is a one-shot command execution, no forwarding needed)
-		args := make([]string, 0, len(hostConfig.SSHOpts)+6) // 4 fixed opts + host + shellCmd
+		args := make([]string, 0, len(hostConfig.SSHOpts)+6)
 		args = append(args, "-o", "ControlMaster=no", "-o", "ClearAllForwardings=yes")
 		args = append(args, hostConfig.SSHOpts...)
-		// Use login shell so ~/.bash_profile / ~/.zprofile are sourced and PATH is resolved.
-		// ${SHELL:-/bin/sh} falls back to /bin/sh if $SHELL is unset on the remote.
-		// Note: remoteCmd must not contain single quotes; guaranteed by validatePath/ValidateIdentifier.
-		shellCmd := `${SHELL:-/bin/sh} -l -c '` + remoteCmd + `'`
-		args = append(args, hostConfig.Host, shellCmd)
+		args = append(args, hostConfig.Host, remoteCmd)
 		return exec.Command("ssh", args...)
 	case "docker":
 		return exec.Command("docker", "exec", hostConfig.Container, "sh", "-c", remoteCmd)
@@ -92,12 +86,7 @@ func startSlaveCommand(hostConfig config.HostConfig, opts ...BootstrapOptions) *
 // StartSlave starts the slave daemon on a remote host and returns the result.
 // Returns an error if ccvalet is not installed on the remote host.
 func StartSlave(hostConfig config.HostConfig, opts ...BootstrapOptions) error {
-	// Validate all inputs before building the shell command (prevent injection)
-	if hostConfig.SocketPath != "" {
-		if err := validatePath(hostConfig.SocketPath); err != nil {
-			return fmt.Errorf("invalid socket path: %w", err)
-		}
-	}
+	// Validate peer options before building the shell command (prevent injection)
 	if len(opts) > 0 && opts[0].PeerSocketPath != "" && opts[0].PeerHostID != "" {
 		if err := validatePath(opts[0].PeerSocketPath); err != nil {
 			return fmt.Errorf("invalid peer socket path: %w", err)
@@ -107,7 +96,7 @@ func StartSlave(hostConfig config.HostConfig, opts ...BootstrapOptions) error {
 		}
 	}
 
-	cmd := startSlaveCommand(hostConfig, opts...)
+	cmd := StartSlaveCommand(hostConfig, opts...)
 	if cmd == nil {
 		return fmt.Errorf("unsupported host type: %s", hostConfig.Type)
 	}

--- a/internal/host/bootstrap_test.go
+++ b/internal/host/bootstrap_test.go
@@ -99,7 +99,7 @@ func TestStartSlaveCommand(t *testing.T) {
 			Type: "ssh",
 			Host: "myhost",
 		}
-		cmd := startSlaveCommand(hc)
+		cmd := StartSlaveCommand(hc)
 		if cmd == nil {
 			t.Fatal("expected non-nil command")
 		}
@@ -110,7 +110,7 @@ func TestStartSlaveCommand(t *testing.T) {
 			"-o", "ControlMaster=no",
 			"-o", "ClearAllForwardings=yes",
 			"myhost",
-			`${SHELL:-/bin/sh} -l -c 'ccvalet daemon start --socket ~/.ccvalet/run/daemon.sock'`,
+			"ccvalet daemon start --socket ~/.ccvalet/run/daemon.sock",
 		}
 		if len(cmd.Args) != len(wantArgs) {
 			t.Fatalf("args length = %d, want %d\ngot:  %v\nwant: %v", len(cmd.Args), len(wantArgs), cmd.Args, wantArgs)
@@ -128,12 +128,12 @@ func TestStartSlaveCommand(t *testing.T) {
 			Host:       "myhost",
 			SocketPath: "/tmp/custom.sock",
 		}
-		cmd := startSlaveCommand(hc)
+		cmd := StartSlaveCommand(hc)
 		if cmd == nil {
 			t.Fatal("expected non-nil command")
 		}
 
-		wantRemoteCmd := `${SHELL:-/bin/sh} -l -c 'ccvalet daemon start --socket /tmp/custom.sock'`
+		wantRemoteCmd := "ccvalet daemon start --socket /tmp/custom.sock"
 		// The remote command is the last element of Args
 		lastArg := cmd.Args[len(cmd.Args)-1]
 		if lastArg != wantRemoteCmd {
@@ -147,7 +147,7 @@ func TestStartSlaveCommand(t *testing.T) {
 			Host:    "myhost",
 			SSHOpts: []string{"-p", "2222", "-i", "/path/to/key"},
 		}
-		cmd := startSlaveCommand(hc)
+		cmd := StartSlaveCommand(hc)
 		if cmd == nil {
 			t.Fatal("expected non-nil command")
 		}
@@ -158,7 +158,7 @@ func TestStartSlaveCommand(t *testing.T) {
 			"-o", "ClearAllForwardings=yes",
 			"-p", "2222", "-i", "/path/to/key",
 			"myhost",
-			`${SHELL:-/bin/sh} -l -c 'ccvalet daemon start --socket ~/.ccvalet/run/daemon.sock'`,
+			"ccvalet daemon start --socket ~/.ccvalet/run/daemon.sock",
 		}
 		if len(cmd.Args) != len(wantArgs) {
 			t.Fatalf("args length = %d, want %d\ngot:  %v\nwant: %v", len(cmd.Args), len(wantArgs), cmd.Args, wantArgs)
@@ -175,7 +175,7 @@ func TestStartSlaveCommand(t *testing.T) {
 			Type:      "docker",
 			Container: "my-container",
 		}
-		cmd := startSlaveCommand(hc)
+		cmd := StartSlaveCommand(hc)
 		if cmd == nil {
 			t.Fatal("expected non-nil command")
 		}
@@ -198,7 +198,7 @@ func TestStartSlaveCommand(t *testing.T) {
 		hc := config.HostConfig{
 			Type: "unknown",
 		}
-		cmd := startSlaveCommand(hc)
+		cmd := StartSlaveCommand(hc)
 		if cmd != nil {
 			t.Errorf("expected nil for unknown type, got %v", cmd)
 		}
@@ -210,24 +210,14 @@ func TestStartSlaveCommand(t *testing.T) {
 			PeerSocketPath: "/tmp/ccvalet-peers/mac/daemon.sock",
 			PeerHostID:     "mac",
 		}
-		cmd := startSlaveCommand(hc, opts)
+		cmd := StartSlaveCommand(hc, opts)
 		if cmd == nil {
 			t.Fatal("expected non-nil command")
 		}
-		wantArgs := []string{
-			"ssh",
-			"-o", "ControlMaster=no",
-			"-o", "ClearAllForwardings=yes",
-			"myhost",
-			`${SHELL:-/bin/sh} -l -c 'ccvalet daemon start --socket ~/.ccvalet/run/daemon.sock --peer-socket /tmp/ccvalet-peers/mac/daemon.sock --peer-id mac'`,
-		}
-		if len(cmd.Args) != len(wantArgs) {
-			t.Fatalf("args length = %d, want %d\ngot:  %v\nwant: %v", len(cmd.Args), len(wantArgs), cmd.Args, wantArgs)
-		}
-		for i, arg := range wantArgs {
-			if cmd.Args[i] != arg {
-				t.Errorf("Args[%d] = %q, want %q", i, cmd.Args[i], arg)
-			}
+		lastArg := cmd.Args[len(cmd.Args)-1]
+		want := "ccvalet daemon start --socket ~/.ccvalet/run/daemon.sock --peer-socket /tmp/ccvalet-peers/mac/daemon.sock --peer-id mac"
+		if lastArg != want {
+			t.Errorf("remote command = %q, want %q", lastArg, want)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- PR #19 (`fix: start remote daemon via login shell to resolve PATH issues`) をrevert
- `${SHELL:-/bin/sh} -l -c '...'` ラッピングを削除し、シンプルな SSH コマンドに戻す
- `StartSlaveCommand` をexportedに戻す

## 理由

ログインシェル (`-l`) では `.bash_profile` / `.zprofile` は読まれるが、`.bashrc` / `.zshrc` は読まれない。
`~/.local/bin` や `~/go/bin` を `.bashrc` にのみ設定している環境では依然として `command not found` になる。

中途半端な回避策であるため、後続PRで `ccvalet_path` 設定オプションを追加して明示的にパスを指定できるようにする。

## 関連

- Closes #14 (再オープン)
- 後続: `ccvalet_path` config オプション追加PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)