### PR TITLE
fix: セッション削除後に右ペインが pane is dead になる問題を修正

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -451,8 +451,13 @@ func (m *Model) switchToSession(sessionID string) {
 		// switch-client failed — fall through to respawn
 	}
 
-	// Local: respawn right pane with inner tmux attach
-	attachCmd := fmt.Sprintf("tmux -L %s attach -t %s", tmux.SocketName, sess.TmuxWindowName)
+	// Local: respawn right pane with inner tmux attach.
+	// Unset $TMUX so tmux does not refuse with "sessions should be nested with care":
+	// the display pane runs inside the outer tmux (ccvalet-mgr), so $TMUX points to
+	// the outer session. Without env -u TMUX, attaching to the inner tmux (ccvalet)
+	// on the same host is rejected as nesting. This mirrors the env -u TMUX pattern
+	// used in session/manager.go when launching CC processes.
+	attachCmd := fmt.Sprintf("env -u TMUX tmux -L %s attach -t %s", tmux.SocketName, sess.TmuxWindowName)
 	_ = m.tmuxClient.RespawnPane(m.displayPaneID, attachCmd)
 	m.displayLocalAttach = true
 
@@ -932,14 +937,16 @@ func (m Model) updateListMode(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Reconnect to session at cursor after delete/kill
 		if m.needsReswitch {
 			m.needsReswitch = false
-			m.currentSessionID = ""      // Force reset
-			m.displayLocalAttach = false // Pane process is dead after delete/kill
+			m.currentSessionID = "" // Force reset
+			if m.displayLocalAttach {
+				m.detachInnerClient()
+				m.displayLocalAttach = false
+			}
 			pageSessions := m.getPageSessions()
 			if len(pageSessions) > 0 && m.cursor < len(pageSessions) {
 				m.switchToSession(pageSessions[m.cursor].ID)
 			} else {
 				m.respawnPlaceholder()
-
 			}
 			m.processingMsg = ""
 			return m, nil


### PR DESCRIPTION
## 変更内容の概要

複数のローカルセッションがある状態でセッションを削除すると、自動フォーカス先の右ペインが「pane is dead」になる問題を修正。

### 根本原因

表示ペイン（右ペイン）は外側tmux (`ccvalet-mgr`) の中で動いており、`$TMUX` 環境変数が外側セッションを指している。この状態で内側tmux (`-L ccvalet`) に `tmux attach` しようとすると、tmuxが「ネストされたセッション」として検出し下記エラーで即座に終了していた：

```
sessions should be nested with care, unset $TMUX to force
```

デバッグログで確認した実際の動作：
- `RespawnPane` 実行直後は `deadAfter=false`（プロセス起動）
- その数ms後に `paneDead=true`（即座に終了）
- `attachExit: code=1 err=sessions should be nested with care, unset $TMUX to force`

### なぜ一部のセッションでは動いていたか

カーソル手動移動には `cursorSettledCmd` の150msデバウンスがある。その間に `SwitchClient` で既存の `tmux attach` プロセスをそのまま使い回すため新プロセスは起動しない。`$TMUX` が内側tmuxを指すよう更新されると、次の `RespawnPane` で内側→内側のネストとして拒否される。

### 修正内容

**`internal/tui/model.go`**

```go
// 変更前
attachCmd := fmt.Sprintf("tmux -L %s attach -t %s", tmux.SocketName, sess.TmuxWindowName)

// 変更後
attachCmd := fmt.Sprintf("env -u TMUX tmux -L %s attach -t %s", tmux.SocketName, sess.TmuxWindowName)
```

`env -u TMUX` で `$TMUX` を除去してから `tmux attach` を実行する。`session/manager.go` でCCプロセス起動時に `env -u TMUX -u TMUX_PANE` を使うパターンと同じ対処。

また `needsReswitch` ハンドラで `detachInnerClient()` を呼んで古い内側tmux接続をグレースフルにクローズしてから次セッションに切り替えるよう修正。

## やってないこと

- `switchToRemoteSession` での SSH アタッチコマンドには同様の問題が起きないことを確認済み（SSH は内側tmuxと無関係）

## 動作確認

1. ccvalet tui を起動
2. ローカルセッションを3つ以上作成
3. いずれかのセッションを選択して `d` → `y` で削除
4. 右ペインが「pane is dead」にならず、次のセッションが正常に表示されることを確認