### PR TITLE
feat: セッション一覧の作業ディレクトリ表示を改善

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -546,9 +546,14 @@ func (m *Manager) startSessionTmux(session *Session) error {
 // It runs git rev-parse (lightweight, <5ms) and acquires the lock internally.
 // lastTrackedPath is used to avoid clearing git info on every poll when already in a non-git dir.
 func (m *Manager) updateGitBranch(session *Session, currentPath, lastTrackedPath string) {
-	cmd := exec.Command("git", "-C", currentPath, "rev-parse", "--abbrev-ref", "HEAD")
+	cmd := exec.Command("git", "-C", currentPath, "rev-parse", "--abbrev-ref", "HEAD", "--show-toplevel")
 	if output, err := cmd.Output(); err == nil {
-		branch := strings.TrimSpace(string(output))
+		lines := strings.SplitN(strings.TrimSpace(string(output)), "\n", 2)
+		branch := lines[0]
+		var repoRoot string
+		if len(lines) >= 2 {
+			repoRoot = filepath.Base(lines[1])
+		}
 		// Detect if currentPath is a git worktree (.git is a file, not a directory)
 		isWorktree := false
 		gitPath := filepath.Join(currentPath, ".git")
@@ -559,6 +564,7 @@ func (m *Manager) updateGitBranch(session *Session, currentPath, lastTrackedPath
 		session.CurrentBranch = branch
 		session.IsGitRepo = true
 		session.IsWorktree = isWorktree
+		session.GitRepoRoot = repoRoot
 		m.mu.Unlock()
 	} else if currentPath != lastTrackedPath {
 		// Only clear git info when entering a non-git directory
@@ -566,6 +572,7 @@ func (m *Manager) updateGitBranch(session *Session, currentPath, lastTrackedPath
 		session.CurrentBranch = ""
 		session.IsGitRepo = false
 		session.IsWorktree = false
+		session.GitRepoRoot = ""
 		m.mu.Unlock()
 	}
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -58,6 +58,7 @@ type Session struct {
 	CurrentBranch  string `json:"-"` // Current git branch
 	IsGitRepo      bool   `json:"-"` // Whether CurrentWorkDir is inside a git repository
 	IsWorktree     bool   `json:"-"` // Whether CurrentWorkDir is a git worktree (not the main repo)
+	GitRepoRoot    string `json:"-"` // Git repository root directory basename (e.g., "myapp")
 }
 
 // Info returns session information for display
@@ -78,6 +79,7 @@ type Info struct {
 	CurrentWorkDir string `json:"current_work_dir,omitempty"` // Current working directory
 	CurrentBranch  string `json:"current_branch,omitempty"`   // Current git branch
 	IsWorktree     bool   `json:"is_worktree,omitempty"`      // Whether WorkDir is a git worktree
+	GitRepoRoot    string `json:"git_repo_root,omitempty"`    // Git repository root basename
 
 	// Last messages from transcript
 	LastUserMessage      string `json:"last_user_message,omitempty"`      // Last user message content (truncated)
@@ -121,5 +123,6 @@ func (s *Session) ToInfo() Info {
 		CurrentWorkDir:  s.CurrentWorkDir,
 		CurrentBranch:   s.CurrentBranch,
 		IsWorktree:      s.IsWorktree,
+		GitRepoRoot:     s.GitRepoRoot,
 	}
 }

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -31,6 +31,7 @@ func TestToInfo_CopiesAllFields(t *testing.T) {
 		CurrentWorkDir: "/home/user/project/subdir",
 		CurrentBranch:  "feature/cool",
 		IsGitRepo:      true,
+		GitRepoRoot:    "project",
 	}
 
 	info := s.ToInfo()
@@ -74,6 +75,9 @@ func TestToInfo_CopiesAllFields(t *testing.T) {
 	}
 	if info.CurrentBranch != s.CurrentBranch {
 		t.Errorf("CurrentBranch: got %q, want %q", info.CurrentBranch, s.CurrentBranch)
+	}
+	if info.GitRepoRoot != s.GitRepoRoot {
+		t.Errorf("GitRepoRoot: got %q, want %q", info.GitRepoRoot, s.GitRepoRoot)
 	}
 
 	// LastUserMessage and LastAssistantMessage are NOT set by ToInfo (populated elsewhere)
@@ -208,6 +212,7 @@ func TestSession_JSONOmitsRuntimeFields(t *testing.T) {
 		CurrentWorkDir: "/tmp/omit/sub",
 		CurrentBranch:  "main",
 		IsGitRepo:      true,
+		GitRepoRoot:    "omit",
 	}
 
 	data, err := json.Marshal(s)
@@ -231,6 +236,8 @@ func TestSession_JSONOmitsRuntimeFields(t *testing.T) {
 		"current_branch",
 		"IsGitRepo",
 		"is_git_repo",
+		"GitRepoRoot",
+		"git_repo_root",
 	}
 
 	for _, field := range runtimeFields {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1306,22 +1306,16 @@ func (m Model) renderHelpLine() string {
 }
 
 // renderSession renders a single session in 1-line format with optional output preview
-// Format: >name (branch)                    STATUS    Last Active
+// Format: >name
 //
-//	details...
+//	├─ STATUS
+//	├─ repo  path (branch)
+//	├─ 👤 user message
+//	└─ 🤖 assistant message
 func (m Model) renderSession(sess session.Info, selected bool, width int) string {
 	var b strings.Builder
 
 	statusIcon, statusLabel, statusStyle := getStatusDisplay(sess.Status)
-
-	// Use LastActiveAt if available, otherwise CreatedAt
-	var lastActiveTime time.Time
-	if !sess.LastActiveAt.IsZero() {
-		lastActiveTime = sess.LastActiveAt
-	} else {
-		lastActiveTime = sess.CreatedAt
-	}
-	timeStr := timeAgo(lastActiveTime)
 
 	// --- Line 1: cursor + session name ---
 	availableForName := width - 2 // cursor(2)
@@ -1335,12 +1329,12 @@ func (m Model) renderSession(sess session.Info, selected bool, width int) string
 	}
 	b.WriteString("\n")
 
-	// Build metadata: [host] workdir (branch)
-	var metaParts []string
+	// Build metadata parts
+	var hostPart string
 	if sess.HostID != "" && sess.HostID != "local" {
-		metaParts = append(metaParts, "["+sess.HostID+"]")
+		hostPart = "[" + sess.HostID + "] "
 	}
-	// Use CurrentWorkDir if available, fall back to WorkDir
+
 	displayDir := sess.CurrentWorkDir
 	if displayDir == "" {
 		displayDir = sess.WorkDir
@@ -1349,46 +1343,77 @@ func (m Model) renderSession(sess session.Info, selected bool, width int) string
 		if home, err := os.UserHomeDir(); err == nil && strings.HasPrefix(displayDir, home) {
 			displayDir = "~" + displayDir[len(home):]
 		}
-		metaParts = append(metaParts, displayDir)
 	}
+
+	branchSuffix := ""
 	if sess.CurrentBranch != "" {
-		metaParts = append(metaParts, "("+sess.CurrentBranch+")")
+		branchSuffix = " (" + sess.CurrentBranch + ")"
+	}
+
+	gitRootPart := ""
+	if sess.GitRepoRoot != "" {
+		gitRootPart = sess.GitRepoRoot + "  "
 	}
 
 	statusStr := statusIcon + " " + statusLabel
-	metaStr := strings.Join(metaParts, " ")
-	indent := "  ├─ "
 	indentWidth := 5
 
-	// Truncate metadata if needed
-	availableForMeta := width - indentWidth
-	if availableForMeta > 0 && runewidth.StringWidth(metaStr) > availableForMeta {
-		metaStr = truncateString(metaStr, availableForMeta)
+	// Determine connectors dynamically (last visible line gets └─)
+	metaConnector := "  ├─ "
+	userConnector := "  ├─ "
+	assistConnector := "  └─ "
+	if sess.LastAssistantMessage == "" {
+		if sess.LastUserMessage != "" {
+			userConnector = "  └─ "
+		} else {
+			metaConnector = "  └─ "
+		}
 	}
 
 	// --- Line 2: status (icon + label) ---
 	if selected {
-		b.WriteString(selectedItemStyle.Render(padLine(indent+statusStr, width)))
+		b.WriteString(selectedItemStyle.Render(padLine("  ├─ "+statusStr, width)))
 	} else {
-		b.WriteString(indent)
+		b.WriteString("  ├─ ")
 		b.WriteString(statusStyle.Render(statusStr))
 	}
 	b.WriteString("\n")
 
-	// --- Line 3: metadata ([host] repo (branch)) ---
-	if metaStr != "" {
+	// --- Line 3: metadata (repo  path (branch)) ---
+	if displayDir != "" || gitRootPart != "" {
+		availableForMeta := width - indentWidth
+		hostWidth := runewidth.StringWidth(hostPart)
+		branchWidth := runewidth.StringWidth(branchSuffix)
+		gitRootWidth := runewidth.StringWidth(gitRootPart)
+		availableForPath := availableForMeta - hostWidth - branchWidth - gitRootWidth
+
 		if selected {
-			b.WriteString(selectedItemStyle.Render(padLine(indent+metaStr, width)))
+			// Plain text for selected style
+			plainPath := truncateStringFromEnd(displayDir, max(availableForPath, 1))
+			metaStr := hostPart + gitRootPart + plainPath + branchSuffix
+			b.WriteString(selectedItemStyle.Render(padLine(metaConnector+metaStr, width)))
 		} else {
-			b.WriteString(indent)
-			b.WriteString(helpStyle.Render(metaStr))
+			b.WriteString(metaConnector)
+			if hostPart != "" {
+				b.WriteString(helpStyle.Render(hostPart))
+			}
+			if gitRootPart != "" {
+				b.WriteString(pathLastSegStyle.Render(sess.GitRepoRoot))
+				b.WriteString(helpStyle.Render("  "))
+			}
+			if displayDir != "" {
+				b.WriteString(renderPathDisplay(displayDir, max(availableForPath, 1)))
+			}
+			if branchSuffix != "" {
+				b.WriteString(helpStyle.Render(branchSuffix))
+			}
 		}
 		b.WriteString("\n")
 	}
 
-	// --- Line 3: last user message ---
+	// --- Line 4: last user message ---
 	if sess.LastUserMessage != "" {
-		prefix := "  ├─ 👤 "
+		prefix := userConnector + "👤 "
 		pWidth := lipgloss.Width(prefix)
 		msgWidth := width - pWidth
 		msgWidth = max(msgWidth, 10)
@@ -1397,14 +1422,14 @@ func (m Model) renderSession(sess session.Info, selected bool, width int) string
 		if selected {
 			b.WriteString(selectedItemStyle.Render(padLine(prefix+msgStr, width)))
 		} else {
-			b.WriteString("  ├─ " + helpStyle.Render("👤 "+msgStr))
+			b.WriteString(userConnector + helpStyle.Render("👤 "+msgStr))
 		}
 		b.WriteString("\n")
 	}
 
-	// --- Line 4: last assistant message ---
+	// --- Line 5: last assistant message ---
 	if sess.LastAssistantMessage != "" {
-		prefix := "  ├─ 🤖 "
+		prefix := assistConnector + "🤖 "
 		pWidth := lipgloss.Width(prefix)
 		msgWidth := width - pWidth
 		msgWidth = max(msgWidth, 10)
@@ -1413,21 +1438,74 @@ func (m Model) renderSession(sess session.Info, selected bool, width int) string
 		if selected {
 			b.WriteString(selectedItemStyle.Render(padLine(prefix+msgStr, width)))
 		} else {
-			b.WriteString("  ├─ " + helpStyle.Render("🤖 "+msgStr))
+			b.WriteString(assistConnector + helpStyle.Render("🤖 "+msgStr))
 		}
 		b.WriteString("\n")
 	}
 
-	// --- Last line: time ---
-	if selected {
-		b.WriteString(selectedItemStyle.Render(padLine("  └─ "+timeStr, width)))
-	} else {
-		b.WriteString("  └─ " + timeStyle.Render(timeStr))
+	// If no metadata, messages — show at least the last connector
+	if displayDir == "" && gitRootPart == "" && sess.LastUserMessage == "" && sess.LastAssistantMessage == "" {
+		if selected {
+			b.WriteString(selectedItemStyle.Render(padLine("  └─", width)))
+		} else {
+			b.WriteString("  └─")
+		}
+		b.WriteString("\n")
 	}
-	b.WriteString("\n")
 
 	return b.String()
 }
+
+// renderPathDisplay renders a directory path with the last segment emphasized.
+// If the path is too long for maxWidth, it truncates from the left,
+// preferring to drop full directory segments at a time.
+func renderPathDisplay(dir string, maxWidth int) string {
+	if dir == "" || maxWidth <= 0 {
+		return ""
+	}
+
+	lastSeg := filepath.Base(dir)
+	prefix := filepath.Dir(dir)
+	if prefix == "." {
+		prefix = ""
+	}
+
+	lastWidth := runewidth.StringWidth(lastSeg)
+
+	// Case: last segment alone is wider than maxWidth
+	if lastWidth > maxWidth {
+		return pathLastSegStyle.Render(truncateToWidth(lastSeg, maxWidth))
+	}
+
+	// Case: no prefix (single segment)
+	if prefix == "" {
+		return pathLastSegStyle.Render(lastSeg)
+	}
+
+	// Case: everything fits
+	full := prefix + "/" + lastSeg
+	if runewidth.StringWidth(full) <= maxWidth {
+		return helpStyle.Render(prefix+"/") + pathLastSegStyle.Render(lastSeg)
+	}
+
+	// Need truncation: try dropping segments from the left
+	trimmed := strings.TrimPrefix(prefix, "/")
+	parts := strings.Split(trimmed, "/")
+	for i := 1; i < len(parts); i++ {
+		candidate := strings.Join(parts[i:], "/")
+		display := "\u2026/" + candidate + "/" + lastSeg
+		if runewidth.StringWidth(display) <= maxWidth {
+			return helpStyle.Render("\u2026/"+candidate+"/") + pathLastSegStyle.Render(lastSeg)
+		}
+	}
+
+	// Fallback: "…/" + lastSeg
+	if 2+lastWidth <= maxWidth {
+		return helpStyle.Render("\u2026/") + pathLastSegStyle.Render(lastSeg)
+	}
+	return pathLastSegStyle.Render(lastSeg)
+}
+
 
 // padLine pads a string to the specified width with spaces.
 func padLine(s string, width int) string {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -609,6 +609,94 @@ func TestTruncateFromEndToWidth(t *testing.T) {
 	}
 }
 
+// --- renderPathDisplay ---
+
+func TestRenderPathDisplay(t *testing.T) {
+	// renderPathDisplay returns lipgloss-styled strings, so we use strings.Contains
+	// to verify the text content rather than exact matching.
+	tests := []struct {
+		name        string
+		dir         string
+		maxWidth    int
+		contains    []string // substrings that must be present
+		notContains []string // substrings that must NOT be present
+	}{
+		{
+			name:     "empty dir",
+			dir:      "",
+			maxWidth: 40,
+			contains: nil,
+		},
+		{
+			name:     "single segment fits",
+			dir:      "myapp",
+			maxWidth: 10,
+			contains: []string{"myapp"},
+		},
+		{
+			name:     "full path fits",
+			dir:      "~/projects/myapp",
+			maxWidth: 40,
+			contains: []string{"~/projects/", "myapp"},
+		},
+		{
+			name:        "path needs truncation",
+			dir:         "~/very/long/path/to/myapp",
+			maxWidth:    20,
+			contains:    []string{"myapp"},
+			notContains: []string{"~/very/long/path/to/"},
+		},
+		{
+			name:        "path with ellipsis",
+			dir:         "~/a/b/c/d/myapp",
+			maxWidth:    14,
+			contains:    []string{"\u2026/", "myapp"},
+			notContains: []string{"~/a/"},
+		},
+		{
+			name:        "only last segment fits",
+			dir:         "~/a/b/c/d/myapp",
+			maxWidth:    7,
+			contains:    []string{"myapp"},
+			notContains: []string{"~/", "/a/"},
+		},
+		{
+			name:     "zero width",
+			dir:      "~/projects/myapp",
+			maxWidth: 0,
+			contains: nil,
+		},
+		{
+			name:     "home dir only",
+			dir:      "~",
+			maxWidth: 10,
+			contains: []string{"~"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := renderPathDisplay(tt.dir, tt.maxWidth)
+			if tt.contains == nil {
+				if got != "" {
+					t.Errorf("renderPathDisplay(%q, %d) = %q, want empty", tt.dir, tt.maxWidth, got)
+				}
+				return
+			}
+			for _, sub := range tt.contains {
+				if !strings.Contains(got, sub) {
+					t.Errorf("renderPathDisplay(%q, %d) = %q, missing %q", tt.dir, tt.maxWidth, got, sub)
+				}
+			}
+			for _, sub := range tt.notContains {
+				if strings.Contains(got, sub) {
+					t.Errorf("renderPathDisplay(%q, %d) = %q, should not contain %q", tt.dir, tt.maxWidth, got, sub)
+				}
+			}
+		})
+	}
+}
+
 // --- buildStatusSummary ---
 
 func TestBuildStatusSummary(t *testing.T) {

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -12,6 +12,7 @@ var (
 	dimColor       = lipgloss.Color("#414868") // Dark gray
 	purpleColor    = lipgloss.Color("#bb9af7") // Purple (thinking)
 	cyanColor      = lipgloss.Color("#7dcfff") // Cyan (running)
+	foregroundColor = lipgloss.Color("#a9b1d6") // Light lavender (text)
 	// Title style (for header inside box)
 	titleStyle = lipgloss.NewStyle().
 			Bold(true).
@@ -34,6 +35,10 @@ var (
 	// Time style
 	timeStyle = lipgloss.NewStyle().
 			Foreground(dimColor)
+
+	// Path last segment style (brighter than helpStyle for emphasis)
+	pathLastSegStyle = lipgloss.NewStyle().
+				Foreground(foregroundColor)
 
 	// Status styles - Tokyo Night inspired
 	thinkingStyle = lipgloss.NewStyle().


### PR DESCRIPTION
## Summary

Closes #30

セッション一覧（左ペイン）の作業ディレクトリ表示を改善する。

## 変更内容

- **GitRepoRoot フィールド追加**: `session.Session` / `session.Info` に `GitRepoRoot` を追加。`git rev-parse --show-toplevel` の basename で取得し、tmux ポーリング時に更新
- **git rev-parse 統合**: `--abbrev-ref HEAD` と `--show-toplevel` を1回の exec で実行（プロセス生成削減）
- **パス表示改善**: `renderPathDisplay()` を新設。左から `…` で省略し、末尾セグメントを `pathLastSegStyle` で強調表示
- **最終アクティブ時刻行の削除**: `└─ N分前` の行を削除してスペースを有効活用
- **コネクタ動的化**: 最後の表示行に `└─`、それ以外に `├─` を動的に決定

### 表示イメージ（変更後）
```
> my-session
  ├─ ▶ RUNNING
  ├─ myapp  …/work/my-repo (main)
  ├─ 👤 ユーザーメッセージ
  └─ 🤖 アシスタントメッセージ
```

## やってないこと

- `IsWorktree` 時のみ `GitRepoRoot` を表示する最適化（設計判断として常に表示する方針）
- `~` パスの特別扱い（truncation 時に `~` を保持する挙動）

## 動作確認

- [x] `make test` — 全テスト PASS
- [x] `make build` — ビルド成功
- [ ] TUI で手動確認（通常リポジトリ / 長いパス / worktree / git 外ディレクトリ）

🤖 Generated with [Claude Code](https://claude.ai/code)