### PR TITLE
feat(config): add global env vars for Claude Code sessions

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
 )
 
 // supportedDetachKeys is the list of supported detach keys
@@ -67,6 +68,7 @@ type Config struct {
 	HostID      string            `mapstructure:"host_id,omitempty"`     // This daemon's host ID (default: "local")
 	Keybindings KeybindingsConfig `mapstructure:"keybindings,omitempty"` // Keybinding settings
 	Hosts       []HostConfig      `mapstructure:"hosts,omitempty"`       // Remote host settings
+	Env         map[string]string `mapstructure:"-"`                     // Custom environment variables (loaded separately to preserve key case)
 }
 
 // Manager manages reading and writing configuration files
@@ -125,8 +127,26 @@ func (m *Manager) load() error {
 		return err
 	}
 
+	cfg.Env = loadEnvFromFile(m.filePath)
 	m.config = cfg
 	return nil
+}
+
+// loadEnvFromFile reads the "env" map from the YAML file directly,
+// preserving the original key case (viper lowercases all keys).
+func loadEnvFromFile(filePath string) map[string]string {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil
+	}
+
+	var raw struct {
+		Env map[string]string `yaml:"env"`
+	}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil
+	}
+	return raw.Env
 }
 
 // Reload re-reads the configuration file
@@ -143,11 +163,13 @@ func (m *Manager) Reload() error {
 		return err
 	}
 
+	cfg.Env = loadEnvFromFile(m.filePath)
 	m.config = cfg
 	return nil
 }
 
-// Save writes the configuration to file
+// Save writes the configuration to file.
+// Note: Env field is not persisted by Save (it is loaded directly from YAML via loadEnvFromFile).
 func (m *Manager) Save() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -161,6 +183,13 @@ func (m *Manager) Get() *Config {
 	defer m.mu.RUnlock()
 
 	cfg := *m.config
+	if cfg.Env != nil {
+		env := make(map[string]string, len(cfg.Env))
+		for k, v := range cfg.Env {
+			env[k] = v
+		}
+		cfg.Env = env
+	}
 	return &cfg
 }
 
@@ -186,6 +215,24 @@ func (m *Manager) GetHost(id string) *HostConfig {
 		}
 	}
 	return nil
+}
+
+// GetEnv returns the custom environment variables configured for Claude Code sessions.
+// Returns an empty map (never nil) if no env vars are configured.
+func (m *Manager) GetEnv() map[string]string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if m.config.Env == nil {
+		return make(map[string]string)
+	}
+
+	// Return a copy to prevent callers from modifying the internal state
+	env := make(map[string]string, len(m.config.Env))
+	for k, v := range m.config.Env {
+		env[k] = v
+	}
+	return env
 }
 
 // GetShell returns the shell to use when launching Claude Code.

--- a/internal/config/config_manager_test.go
+++ b/internal/config/config_manager_test.go
@@ -249,6 +249,67 @@ func TestConfigManager_Reload_UpdatesConfig(t *testing.T) {
 	}
 }
 
+func TestConfigManager_GetEnv_DefaultEmpty(t *testing.T) {
+	m, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	env := m.GetEnv()
+	if env == nil {
+		t.Fatal("GetEnv() returned nil, want empty map")
+	}
+	if len(env) != 0 {
+		t.Errorf("GetEnv() length: got %d, want 0", len(env))
+	}
+}
+
+func TestConfigManager_GetEnv_Configured(t *testing.T) {
+	dir := t.TempDir()
+	yamlContent := "env:\n  CLAUDE_MODEL: claude-sonnet-4-6-20250514\n  MY_VAR: hello\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(yamlContent), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	m, err := NewManager(dir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	env := m.GetEnv()
+	if len(env) != 2 {
+		t.Fatalf("GetEnv() length: got %d, want 2", len(env))
+	}
+	if env["CLAUDE_MODEL"] != "claude-sonnet-4-6-20250514" {
+		t.Errorf("CLAUDE_MODEL: got %q, want %q", env["CLAUDE_MODEL"], "claude-sonnet-4-6-20250514")
+	}
+	if env["MY_VAR"] != "hello" {
+		t.Errorf("MY_VAR: got %q, want %q", env["MY_VAR"], "hello")
+	}
+}
+
+func TestConfigManager_GetEnv_ReturnsCopy(t *testing.T) {
+	dir := t.TempDir()
+	yamlContent := "env:\n  KEY1: value1\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(yamlContent), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	m, err := NewManager(dir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	env := m.GetEnv()
+	env["KEY1"] = "modified"
+
+	// Original should be unchanged
+	env2 := m.GetEnv()
+	if env2["KEY1"] != "value1" {
+		t.Errorf("GetEnv() returned reference instead of copy: got %q, want %q", env2["KEY1"], "value1")
+	}
+}
+
 func TestConfigManager_Reload_InvalidYAML(t *testing.T) {
 	dir := t.TempDir()
 	m, err := NewManager(dir)

--- a/internal/session/env.go
+++ b/internal/session/env.go
@@ -1,0 +1,48 @@
+package session
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// validEnvKeyPattern matches valid environment variable key names.
+// Must start with a letter or underscore, followed by letters, digits, or underscores.
+var validEnvKeyPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// buildEnvString builds a shell-safe environment variable string from the given map.
+// Keys are sorted for deterministic output. Invalid keys are skipped with a warning.
+// Values are shell-escaped by wrapping in single quotes and escaping embedded single quotes.
+func buildEnvString(envMap map[string]string) string {
+	if len(envMap) == 0 {
+		return ""
+	}
+
+	// Sort keys for deterministic output
+	keys := make([]string, 0, len(envMap))
+	for k := range envMap {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var parts []string
+	for _, k := range keys {
+		if !validEnvKeyPattern.MatchString(k) {
+			debugLog("WARNING: skipping invalid env key %q (must match %s)", k, validEnvKeyPattern.String())
+			continue
+		}
+		v := shellEscape(envMap[k])
+		parts = append(parts, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	return strings.Join(parts, " ")
+}
+
+// shellEscape wraps a value in single quotes and escapes any embedded single quotes.
+// The escape sequence for a single quote within single quotes is: '\''
+// (end quote, escaped quote, start quote)
+func shellEscape(s string) string {
+	escaped := strings.ReplaceAll(s, "'", "'\\''")
+	return "'" + escaped + "'"
+}

--- a/internal/session/env_test.go
+++ b/internal/session/env_test.go
@@ -1,0 +1,131 @@
+package session
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildEnvString_Empty(t *testing.T) {
+	got := buildEnvString(nil)
+	if got != "" {
+		t.Errorf("buildEnvString(nil) = %q, want empty string", got)
+	}
+
+	got = buildEnvString(map[string]string{})
+	if got != "" {
+		t.Errorf("buildEnvString(empty) = %q, want empty string", got)
+	}
+}
+
+func TestBuildEnvString_SingleVar(t *testing.T) {
+	got := buildEnvString(map[string]string{"MY_VAR": "hello"})
+	want := "MY_VAR='hello'"
+	if got != want {
+		t.Errorf("buildEnvString = %q, want %q", got, want)
+	}
+}
+
+func TestBuildEnvString_MultipleVarsSorted(t *testing.T) {
+	env := map[string]string{
+		"ZEBRA":  "z",
+		"ALPHA":  "a",
+		"MIDDLE": "m",
+	}
+	got := buildEnvString(env)
+	want := "ALPHA='a' MIDDLE='m' ZEBRA='z'"
+	if got != want {
+		t.Errorf("buildEnvString = %q, want %q", got, want)
+	}
+}
+
+func TestBuildEnvString_ShellEscaping(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{
+			name:  "value with single quote",
+			value: "it's here",
+			want:  "KEY='it'\\''s here'",
+		},
+		{
+			name:  "value with spaces",
+			value: "hello world",
+			want:  "KEY='hello world'",
+		},
+		{
+			name:  "value with double quotes",
+			value: `say "hi"`,
+			want:  `KEY='say "hi"'`,
+		},
+		{
+			name:  "value with special chars",
+			value: "a$b`c\\d",
+			want:  "KEY='a$b`c\\d'",
+		},
+		{
+			name:  "empty value",
+			value: "",
+			want:  "KEY=''",
+		},
+		{
+			name:  "value with multiple single quotes",
+			value: "a'b'c",
+			want:  "KEY='a'\\''b'\\''c'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildEnvString(map[string]string{"KEY": tt.value})
+			if got != tt.want {
+				t.Errorf("buildEnvString = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildEnvString_InvalidKeysSkipped(t *testing.T) {
+	env := map[string]string{
+		"VALID_KEY":    "ok",
+		"123INVALID":   "bad",
+		"ALSO-INVALID": "bad",
+		"KEY WITH SPC": "bad",
+		"":             "bad",
+		"OK_2":         "ok",
+	}
+	got := buildEnvString(env)
+
+	// Only VALID_KEY and OK_2 should be present (sorted)
+	want := "OK_2='ok' VALID_KEY='ok'"
+	if got != want {
+		t.Errorf("buildEnvString = %q, want %q", got, want)
+	}
+
+	// Make sure invalid keys are not present
+	for _, bad := range []string{"123INVALID", "ALSO-INVALID", "KEY WITH SPC"} {
+		if strings.Contains(got, bad) {
+			t.Errorf("buildEnvString output contains invalid key %q", bad)
+		}
+	}
+}
+
+func TestBuildEnvString_ValidKeyPatterns(t *testing.T) {
+	// These should all be accepted
+	validKeys := map[string]string{
+		"A":          "v",
+		"_PRIVATE":   "v",
+		"MY_VAR_123": "v",
+		"lowercase":  "v",
+		"MixedCase":  "v",
+		"_":          "v",
+	}
+	got := buildEnvString(validKeys)
+
+	// All 6 keys should be present
+	parts := strings.Split(got, " ")
+	if len(parts) != 6 {
+		t.Errorf("expected 6 env vars, got %d: %q", len(parts), got)
+	}
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -498,8 +498,13 @@ func (m *Manager) startSessionTmux(session *Session) error {
 	// (tmux's -c flag doesn't expand ~, and RespawnPane doesn't accept -c at all)
 	// Use ; instead of && so cd failure doesn't prevent claude from starting
 	shellDir := workDirForShell(session.WorkDir)
-	shellCmd := fmt.Sprintf("cd \"%s\" 2>/dev/null; env -u TMUX -u TMUX_PANE -u CLAUDECODE CCVALET_SESSION_ID=%s TERM=xterm-256color COLORTERM=truecolor FORCE_COLOR=1 %s -ic '%s'",
-		shellDir, session.ID, shell, claudeCmd)
+	customEnv := buildEnvString(m.configMgr.GetEnv())
+	envVars := fmt.Sprintf("CCVALET_SESSION_ID=%s TERM=xterm-256color COLORTERM=truecolor FORCE_COLOR=1", session.ID)
+	if customEnv != "" {
+		envVars += " " + customEnv
+	}
+	shellCmd := fmt.Sprintf("cd \"%s\" 2>/dev/null; env -u TMUX -u TMUX_PANE -u CLAUDECODE %s %s -ic '%s'",
+		shellDir, envVars, shell, claudeCmd)
 
 	innerSessionName := tmux.InnerSessionName(session.ID)
 
@@ -634,8 +639,13 @@ func (m *Manager) captureOutputTmux(session *Session) {
 
 				shell := m.configMgr.GetShell()
 				shellDir := workDirForShell(session.WorkDir)
-				shellCmd := fmt.Sprintf("cd \"%s\" 2>/dev/null; env -u TMUX -u TMUX_PANE -u CLAUDECODE CCVALET_SESSION_ID=%s TERM=xterm-256color COLORTERM=truecolor FORCE_COLOR=1 %s -ic 'claude --session-id %s'",
-					shellDir, session.ID, shell, newSessionID)
+				customEnv := buildEnvString(m.configMgr.GetEnv())
+				envVars := fmt.Sprintf("CCVALET_SESSION_ID=%s TERM=xterm-256color COLORTERM=truecolor FORCE_COLOR=1", session.ID)
+				if customEnv != "" {
+					envVars += " " + customEnv
+				}
+				shellCmd := fmt.Sprintf("cd \"%s\" 2>/dev/null; env -u TMUX -u TMUX_PANE -u CLAUDECODE %s %s -ic 'claude --session-id %s'",
+					shellDir, envVars, shell, newSessionID)
 				if err := m.tmuxClient.RespawnPane(target, shellCmd); err == nil {
 					m.mu.Lock()
 					session.Status = StatusRunning


### PR DESCRIPTION
## 概要

`~/.ccvalet/config.yaml` の `env:` セクションでカスタム環境変数を定義し、全Claude Codeセッション起動時に渡せるようにする機能を追加。

```yaml
env:
  CLAUDE_MODEL: "claude-sonnet-4-6-20250514"
  MY_CUSTOM_VAR: "value"
```

## 変更内容

- `Config` structに `Env map[string]string` フィールドを追加
- viperのキー小文字化問題を回避するため `mapstructure:"-"` + `gopkg.in/yaml.v3` で直接パース
- `buildEnvString()` / `shellEscape()` でシェルセーフな環境変数文字列を構築
- 通常起動・リトライ再起動の両箇所でカスタム環境変数を適用
- 環境変数キーのバリデーション（`^[A-Za-z_][A-Za-z0-9_]*$`）
- `Get()` / `GetEnv()` でディープコピーを返し内部状態を保護

## やっていないこと

- セッション単位の環境変数設定（将来拡張）
- `TMUX`/`TMUX_PANE`/`CLAUDECODE` のブロックリスト（予防的対応、低リスク）

## テスト

- `internal/config/`: GetEnv のデフォルト空map、YAML読み込み、コピー保護
- `internal/session/`: 空map、単一変数、ソート順、シェルエスケープ(6パターン)、不正キースキップ、有効キーパターン
- `go test ./internal/config/ ./internal/session/` 全パス
- `make build` 成功