### PR TITLE
fix(tui): Enterキーでセッションにアタッチできないバグを修正

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -594,6 +594,9 @@ func (m Model) handleSelectSession() (tea.Model, tea.Cmd) {
 			m.currentSessionID = ""
 		}
 		m.switchToSession(sess.ID)
+		if m.displayPaneID != "" {
+			_ = m.tmuxClient.SelectPane(m.displayPaneID)
+		}
 		return m, m.fetchSessions
 	}
 	return m, nil


### PR DESCRIPTION
## 概要

PR #41 (`feat/tui-enter-to-switch-session`) で `handleAttach` → `handleSelectSession` にリネームした際、右ペインへのフォーカス移動処理（`SelectPane` 呼び出し）が削除されていた。これにより、Enterキーを押しても右ペインのプレビューが切り替わるだけで、セッションにアタッチ（フォーカス移動）できなくなっていた。

## 変更内容

- `handleSelectSession` 内の `switchToSession` 呼び出し後に `SelectPane(m.displayPaneID)` を再追加（3行）

## やってないこと

- なし（最小限の修正）

## 動作確認

- [x] `make test` 全パス
- [x] `make build` 成功
- [ ] TUI上でEnterキーでセッションにアタッチできることを手動確認
- [ ] 検索モード中のEnterでもアタッチできることを手動確認
- [ ] viewed表示（▎マーカー）が引き続き正しく表示されることを確認