### PR TITLE
chore: exclude merge/chore/style commits from goreleaser changelog

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,6 +34,11 @@ changelog:
       - "^docs:"
       - "^test:"
       - "^ci:"
+      - "^chore:"
+      - "^style:"
+      - "^Merge pull request"
+      - "^Merge branch"
+      - "^Merge remote-tracking"
   groups:
     - title: Features
       regexp: '^feat'


### PR DESCRIPTION
## Summary
- Add merge / chore / style commit patterns to `.goreleaser.yml` `changelog.filters.exclude`
- Prevents the v0.2.0-style noise where every "Merge pull request #N" commit ended up in the Others section

## Background
v0.2.0 release notes leaked 30+ merge commits into the changelog. Manually edited the release page already; this PR fixes the config so the next release is clean from the start.

## Test plan
- [ ] Confirm next tag push produces a changelog without `Merge pull request`, `chore:`, or `style:` entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)