### PR TITLE
fix(session): remove worktree using CurrentWorkDir and surface non-worktree as error

### DIFF
--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -236,6 +236,9 @@ func (c *Client) Delete(id, hostID string, removeWorktree, forceRemoveWorktree b
 		if strings.Contains(resp.Error, session.ErrWorktreeDirty.Error()) {
 			return session.ErrWorktreeDirty
 		}
+		if strings.Contains(resp.Error, session.ErrNotWorktree.Error()) {
+			return session.ErrNotWorktree
+		}
 		return errors.New(resp.Error)
 	}
 	return nil

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -25,6 +25,12 @@ var debugLog = debug.NewLogger("daemon-debug.log")
 // and force removal was not requested.
 var ErrWorktreeDirty = errors.New("worktree has uncommitted changes")
 
+// ErrNotWorktree is returned when worktree removal was requested but the
+// resolved target directory is not a git worktree (e.g., the main repository
+// or a non-git directory). Returned instead of silently succeeding so the
+// caller can surface the discrepancy to the user.
+var ErrNotWorktree = errors.New("path is not a git worktree")
+
 // Manager manages multiple Claude Code sessions
 type Manager struct {
 	sessions   map[string]*Session
@@ -424,6 +430,42 @@ func isWorktreePath(path string) bool {
 func isGitRoot(path string) bool {
 	_, err := os.Stat(filepath.Join(path, ".git"))
 	return err == nil
+}
+
+// isGitWorktreeDir returns true when the directory at path is a git worktree
+// (its .git entry is a regular file that points at the main repo). Returns
+// false for the main repo (.git is a directory) or non-git directories.
+func isGitWorktreeDir(path string) bool {
+	if path == "" {
+		return false
+	}
+	fi, err := os.Lstat(filepath.Join(path, ".git"))
+	if err != nil {
+		return false
+	}
+	return fi.Mode().IsRegular()
+}
+
+// resolveWorktreeDir picks the best path to use when removing the session's
+// git worktree. Prefers currentWorkDir (persisted, reflects most recent CWD)
+// when it is a worktree, then workDir. Falls back to either even when neither
+// is a worktree so removeGitWorktree can return ErrNotWorktree against the
+// caller's intent rather than silently doing nothing.
+//
+// Takes the two paths as strings (rather than *Session) so the caller can
+// snapshot them under the manager lock and run the os.Lstat probes outside
+// the critical section.
+func resolveWorktreeDir(currentWorkDir, workDir string) string {
+	if isGitWorktreeDir(currentWorkDir) {
+		return currentWorkDir
+	}
+	if isGitWorktreeDir(workDir) {
+		return workDir
+	}
+	if currentWorkDir != "" {
+		return currentWorkDir
+	}
+	return workDir
 }
 
 // expandTilde expands a leading ~ in a path to the current user's home directory.
@@ -942,14 +984,20 @@ func (m *Manager) Delete(id string, removeWorktree, forceRemoveWorktree bool) er
 		return fmt.Errorf("session %s not found", id)
 	}
 
-	workDir := session.WorkDir
+	currentWorkDir := session.CurrentWorkDir
+	persistedWorkDir := session.WorkDir
 	m.mu.Unlock()
 
+	// Resolve the actual worktree path outside the lock — resolveWorktreeDir
+	// performs os.Lstat probes which would otherwise block other goroutines.
+	workDir := resolveWorktreeDir(currentWorkDir, persistedWorkDir)
+
 	// Remove worktree if requested (outside lock to avoid blocking during exec).
-	// This runs before tmux kill so that ErrWorktreeDirty can abort without side effects.
+	// This runs before tmux kill so that ErrWorktreeDirty / ErrNotWorktree can
+	// abort without side effects.
 	if removeWorktree && workDir != "" {
 		if err := m.removeGitWorktree(workDir, forceRemoveWorktree); err != nil {
-			if errors.Is(err, ErrWorktreeDirty) {
+			if errors.Is(err, ErrWorktreeDirty) || errors.Is(err, ErrNotWorktree) {
 				return err
 			}
 			debugLog("[DELETE] worktree removal failed for %s: %v", workDir, err)
@@ -974,18 +1022,24 @@ func (m *Manager) Delete(id string, removeWorktree, forceRemoveWorktree bool) er
 }
 
 // removeGitWorktree removes a git worktree at the given path.
-// Returns ErrWorktreeDirty if the worktree has uncommitted changes and force is false.
+// Returns ErrWorktreeDirty if the worktree has uncommitted changes and force
+// is false. Returns ErrNotWorktree if workDir is not a git worktree (e.g.,
+// the main repository or a non-git directory) so the caller can surface the
+// discrepancy. A non-existent directory is treated as already-removed and
+// returns nil to keep removal idempotent.
 func (m *Manager) removeGitWorktree(workDir string, force bool) error {
-	// Skip if directory doesn't exist
+	// Idempotent: directory already gone (e.g., removed manually).
 	if _, err := os.Stat(workDir); os.IsNotExist(err) {
 		return nil
 	}
 
-	// Verify it's actually a worktree (.git is a file, not a directory)
+	// Verify it's actually a worktree (.git must be a regular file, not a
+	// directory). The main repo or non-git dirs are refused to protect them
+	// from accidental removal.
 	gitPath := filepath.Join(workDir, ".git")
 	fi, err := os.Lstat(gitPath)
-	if err != nil || fi.IsDir() {
-		return nil // Not a worktree; skip silently
+	if err != nil || !fi.Mode().IsRegular() {
+		return ErrNotWorktree
 	}
 
 	// Read .git file to find the main repo
@@ -996,7 +1050,7 @@ func (m *Manager) removeGitWorktree(workDir string, force bool) error {
 	}
 	raw := strings.TrimSpace(string(content))
 	if !strings.HasPrefix(raw, "gitdir: ") {
-		return nil // Not a standard worktree .git file
+		return ErrNotWorktree
 	}
 	gitdir := strings.TrimPrefix(raw, "gitdir: ")
 

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -2,7 +2,9 @@ package session
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -1725,5 +1727,162 @@ func TestManager_HandleHookEvent_CWDUpdate_WorktreePathSkipped(t *testing.T) {
 	// CurrentWorkDir should still be updated
 	if got.CurrentWorkDir != worktreeDir {
 		t.Errorf("CurrentWorkDir = %q, want %q", got.CurrentWorkDir, worktreeDir)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Worktree removal tests (Delete + removeGitWorktree)
+// ---------------------------------------------------------------------------
+
+// setupTestWorktree initializes a fresh git repo at a temp dir and adds a
+// worktree under it. Returns (mainRepoDir, worktreeDir). Skips the test if
+// `git` is not on PATH.
+func setupTestWorktree(t *testing.T) (string, string) {
+	t.Helper()
+
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	repoDir := t.TempDir()
+
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", repoDir}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %s: %s: %v", strings.Join(args, " "), out, err)
+		}
+	}
+
+	runGit("init")
+	runGit("config", "user.email", "test@test.com")
+	runGit("config", "user.name", "test")
+
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("init"), 0644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runGit("add", ".")
+	runGit("commit", "-m", "init")
+
+	worktreeDir := filepath.Join(repoDir, "wt")
+	runGit("worktree", "add", worktreeDir, "-b", "test-branch")
+
+	return repoDir, worktreeDir
+}
+
+func TestManager_Delete_RemovesWorktree(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	_, worktreeDir := setupTestWorktree(t)
+
+	sess, err := mgr.CreateWithOptions(CreateOptions{WorkDir: worktreeDir, Name: "wt"})
+	if err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+
+	if err := mgr.Delete(sess.ID, true, false); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	if _, err := os.Stat(worktreeDir); !os.IsNotExist(err) {
+		t.Errorf("worktree directory should be removed, but still exists: stat err=%v", err)
+	}
+}
+
+func TestManager_Delete_PrefersCurrentWorkDirForWorktree(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	mainRepo, worktreeDir := setupTestWorktree(t)
+
+	// Reproduce the bug: WorkDir points at the main repo (because the
+	// fix-worktree-workdir-overwrite guard prevents WorkDir from being
+	// updated to a worktree path), while CurrentWorkDir tracks the actual
+	// worktree the session is in.
+	sess, err := mgr.CreateWithOptions(CreateOptions{WorkDir: mainRepo, Name: "wt-current"})
+	if err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+	mgr.mu.Lock()
+	sess.CurrentWorkDir = worktreeDir
+	mgr.mu.Unlock()
+
+	if err := mgr.Delete(sess.ID, true, false); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	if _, err := os.Stat(worktreeDir); !os.IsNotExist(err) {
+		t.Errorf("worktree directory should be removed, but still exists: stat err=%v", err)
+	}
+	// Main repo must remain intact.
+	if _, err := os.Stat(filepath.Join(mainRepo, ".git")); err != nil {
+		t.Errorf("main repo .git should still exist: %v", err)
+	}
+}
+
+func TestManager_Delete_NonWorktreeReturnsError(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	mainRepo, _ := setupTestWorktree(t)
+
+	// Both WorkDir and CurrentWorkDir point at the main repo (no worktree).
+	sess, err := mgr.CreateWithOptions(CreateOptions{WorkDir: mainRepo, Name: "main-only"})
+	if err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+
+	err = mgr.Delete(sess.ID, true, false)
+	if !errors.Is(err, ErrNotWorktree) {
+		t.Fatalf("expected ErrNotWorktree, got: %v", err)
+	}
+
+	// Session must still exist (Delete aborted before tmux kill / store removal).
+	if _, ok := mgr.Get(sess.ID); !ok {
+		t.Error("session should still exist after ErrNotWorktree")
+	}
+	// Main repo must remain intact.
+	if _, err := os.Stat(filepath.Join(mainRepo, ".git")); err != nil {
+		t.Errorf("main repo .git should still exist: %v", err)
+	}
+}
+
+func TestManager_Delete_DirtyWorktreeReturnsErrWorktreeDirty(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	_, worktreeDir := setupTestWorktree(t)
+
+	if err := os.WriteFile(filepath.Join(worktreeDir, "dirty.txt"), []byte("uncommitted"), 0644); err != nil {
+		t.Fatalf("write dirty file: %v", err)
+	}
+
+	sess, err := mgr.CreateWithOptions(CreateOptions{WorkDir: worktreeDir, Name: "wt-dirty"})
+	if err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+
+	err = mgr.Delete(sess.ID, true, false)
+	if !errors.Is(err, ErrWorktreeDirty) {
+		t.Fatalf("expected ErrWorktreeDirty, got: %v", err)
+	}
+
+	if _, err := os.Stat(worktreeDir); err != nil {
+		t.Errorf("worktree should still exist after dirty rejection: %v", err)
+	}
+
+	// Force removal should succeed.
+	if err := mgr.Delete(sess.ID, true, true); err != nil {
+		t.Fatalf("force Delete failed: %v", err)
+	}
+	if _, err := os.Stat(worktreeDir); !os.IsNotExist(err) {
+		t.Errorf("worktree should be removed after force delete: stat err=%v", err)
+	}
+}
+
+func TestRemoveGitWorktree_AlreadyDeletedIsIdempotent(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	_, worktreeDir := setupTestWorktree(t)
+
+	// Remove the worktree directory out-of-band.
+	if err := os.RemoveAll(worktreeDir); err != nil {
+		t.Fatalf("pre-remove worktree: %v", err)
+	}
+
+	if err := mgr.removeGitWorktree(worktreeDir, false); err != nil {
+		t.Errorf("removeGitWorktree on missing dir should be nil, got: %v", err)
 	}
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -737,6 +737,12 @@ func (m Model) updateListMode(msg tea.Msg) (tea.Model, tea.Cmd) {
 						if errors.Is(err, session.ErrWorktreeDirty) {
 							return worktreeDirtyMsg{sessionID: deleteID, hostID: deleteHostID, name: deleteName}
 						}
+						if errors.Is(err, session.ErrNotWorktree) {
+							return deleteErrMsg{
+								sessionID: deleteID,
+								err:       fmt.Errorf("worktree not found for session %q (already removed, or session is not in a worktree)", deleteName),
+							}
+						}
 						return deleteErrMsg{sessionID: deleteID, err: fmt.Errorf("delete failed: %w", err)}
 					}
 					sessions, err := client.List()

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/takaaki-s/claude-code-valet/internal/config"
 	"github.com/takaaki-s/claude-code-valet/internal/session"
 )


### PR DESCRIPTION
## 概要

TUI でセッション削除時に「w（session + worktree 削除）」を選択しても、実際には worktree が削除されないバグを修正します。エラーも出ないため、ユーザーは worktree が掃除されたと誤認していました。

## 背景

過去の修正 [fix-worktree-workdir-overwrite] により `session.WorkDir` は worktree パスで上書きされない仕様になっています。これにより、worktree セッションでも `session.WorkDir` がメインリポジトリを指すケースが発生し、`Delete()` がメインリポを `removeGitWorktree()` に渡す → `.git` がディレクトリ判定でサイレント return → worktree が残存、という連鎖が起きていました。

## 変更内容

### 削除対象パスの解決を CurrentWorkDir 優先に
- `resolveWorktreeDir(currentWorkDir, workDir string) string` を追加
- `.git` が regular file かどうかでベースに判定（`isGitWorktreeDir`）
- `Manager.Delete()` ではロック内で文字列スナップショットのみ取り、`os.Lstat` を含む解決処理はロック外で実行

### サイレント return を ErrNotWorktree に置き換え
- `removeGitWorktree()` の "`.git` がディレクトリ" / "`gitdir:` プレフィックス無し" 経路を `ErrNotWorktree` 返却に変更
- ディレクトリ不在の冪等性ケースのみ `nil` 維持

### IPC / TUI でのエラー伝搬
- `internal/daemon/client.go` で `ErrNotWorktree` を typed error にマップ（`ErrWorktreeDirty` と同パターン）
- `internal/tui/model.go` の「w」キーハンドラで `ErrNotWorktree` を分岐し、ユーザーフレンドリーな `deleteErrMsg` を返す

### 単体テスト追加
`internal/session/manager_test.go` に以下 5 本を追加：
- `TestManager_Delete_RemovesWorktree` — 正常系
- `TestManager_Delete_PrefersCurrentWorkDirForWorktree` — **本バグの再現テスト**
- `TestManager_Delete_NonWorktreeReturnsError` — メインリポは削除されないことを確認
- `TestManager_Delete_DirtyWorktreeReturnsErrWorktreeDirty` — 既存挙動の回帰
- `TestRemoveGitWorktree_AlreadyDeletedIsIdempotent` — 冪等性

テストヘルパ `setupTestWorktree(t)` で実 `git init` + `git worktree add` した一時リポを使用。

## やってないこと

- リモートホスト（SSH/Docker）経由の worktree 削除挙動の検証（次フェーズ）
- TUI の force-delete (`F` キー) フローは既存挙動のまま

## 残課題

- **[ask]**: `WorkDir=mainRepo` + `CurrentWorkDir=空` + worktree 手動削除済みの組み合わせで `ErrNotWorktree` が返る可能性。仕様として許容するか要判断。許容しないなら `os.IsNotExist` チェックを `resolveWorktreeDir` 段階に前倒しする追加修正が必要。

## 動作確認

### 自動
- `make test` PASS 366 / FAIL 0
- `make lint` clean (golangci-lint v1.64.8)
- `make test-race` PASS（want 修正でロック取得タイミングを変更したため race detector でも追加検証）
- `make build` 成功（`bin/ccvalet` 13MB）

### 手動 TUI 操作（ユニットテストで等価検証済み）
worktree セッションを切って TUI から削除する以下の手順は、`TestManager_Delete_RemovesWorktree` および `TestManager_Delete_PrefersCurrentWorkDirForWorktree` で再現済みです：

1. `git worktree add .claude/worktrees/test-w001 -b test/w001`
2. `bin/ccvalet create --workdir $(pwd)/.claude/worktrees/test-w001 --name test-w001`
3. TUI で対象セッションを選択 → `d` → `w` → `y`
4. `git worktree list` から該当 worktree が消えていることを確認

修正前: worktree が残存（バグ）
修正後: worktree が削除される

## メインリポ削除防止

二重ガードは健在：
1. `removeGitWorktree` 側で `.git` がディレクトリの場合は `ErrNotWorktree` を返す
2. `git worktree remove` 自体がメインの worktree を拒否する
